### PR TITLE
Set up a RabbitMQ instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Setting up a working cluster only involves starting up the vagrant machines in a
 ```
 cd cami-project/vagrant
 vagrant up cami-store
+vagrant up cami-rabbitmq-server
 vagrant up cami-medical-compliance
 ```
 You can check that all is in order by accessing this url: `http://192.168.73.12:8000/api/v1/medication-plans/`
@@ -46,6 +47,20 @@ basic schema for the database. It also creates a user with name `cami` and passw
 has full privileges and can connect from any host.
 
 The predefined ip for the `cami-store` instance is: `192.168.73.11`.
+
+### cami-rabbitmq-server
+
+This instance hosts a Rabbit MQ server that will be used as a message broker by all **cami**
+components.
+
+The provisioning script installs the RabbitMQ instance, creates a `cami` vhost and a `cami` user
+with full permissions on that vhost.
+
+Provisioning also enables the management plugin which allows managing the server through a web api.
+The management interface can be accessed at `http://192.168.73.13:15672/` with user `guest` and
+password `guest`.
+
+The predefined ip for the `cami-rabbitmq-server` instance is: `192.168.73.13`.
 
 ### cami-medical-compliance
 

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -8,4 +8,10 @@ mysql_cami_pass: cami
 
 project_dir: /home/vagrant/cami-project
 
+rabbitmq_cami_user: cami
+rabbitmq_cami_pass: cami
+rabbitmq_cami_vhost: /cami
+
 store_ip: 192.168.73.11
+medical_compliance_ip: 192.168.73.12
+rabbitmq_server_ip: 192.168.73.13

--- a/ansible/rabbitmq_server.yml
+++ b/ansible/rabbitmq_server.yml
@@ -1,0 +1,31 @@
+---
+- name: Setup RabbitMQ server instance
+  hosts: all
+
+  roles:
+    - rabbitmq
+
+  tasks:
+    - block:
+      - name: Read rabbitmq users
+        command: rabbitmqctl list_users
+        register: rabbitmq_users
+
+      - name: Create cami user
+        command: rabbitmqctl add_user "{{ rabbitmq_cami_user }}" "{{ rabbitmq_cami_pass }}"
+        when: rabbitmq_users.stdout.find("{{ rabbitmq_cami_user }}") == -1
+
+      - name: Read rabbitmq vhosts
+        command: rabbitmqctl list_vhosts
+        register: rabbitmq_vhosts
+
+      - block:
+        - name: Add cami vhost
+          command: rabbitmqctl add_vhost "{{ rabbitmq_cami_vhost }}"
+
+        - name: Give permission to cami user on cami vhost
+          command: rabbitmqctl set_permissions -p "{{ rabbitmq_cami_vhost }}" "{{ rabbitmq_cami_user }}" ".*" ".*" ".*"
+
+        when: rabbitmq_vhosts.stdout.find("{{ rabbitmq_cami_vhost }}") == -1
+
+      become: yes

--- a/ansible/roles/rabbitmq/handlers/main.yml
+++ b/ansible/roles/rabbitmq/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: restart rabbitmq-server
+  service: name=rabbitmq-server state=restarted
+  become: yes

--- a/ansible/roles/rabbitmq/tasks/main.yml
+++ b/ansible/roles/rabbitmq/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- block:
+    - name: Add RabbitMQ repo key
+      apt_key:
+        url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+        state: present
+
+    - name: Add RabitMQ apt repository
+      apt_repository:
+        repo: 'deb http://archive.canonical.com/ubuntu hardy partner'
+        update_cache: yes
+        state: present
+
+    - name: Install rabbitmq-server
+      apt: pkg={{ item }} state=installed update-cache=yes
+      with_items:
+       - rabbitmq-server
+
+    - name: Read rabbitmq management plugin status
+      command: rabbitmq-plugins list -E rabbitmq_management
+      register: enabled_plugin
+
+    - name: Enable rabbitmq management plugin
+      command: rabbitmq-plugins enable rabbitmq_management
+      when: enabled_plugin.stdout == ""
+      notify:
+         - restart rabbitmq-server
+
+  become: yes

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -118,4 +118,14 @@ Vagrant.configure(2) do |config|
         ansible.playbook = "medical_compliance.yml"
     end
   end
+
+  config.vm.define 'cami-rabbitmq-server', autostart: false do |rabbit|
+    rabbit.vm.hostname = 'cami-rabbitmq-server'
+    rabbit.vm.network 'private_network', ip: '192.168.73.13'
+
+    rabbit.vm.provision "ansible_local" do |ansible|
+        ansible.provisioning_path = "/home/vagrant/cami-project/ansible"
+        ansible.playbook = "rabbitmq_server.yml"
+    end
+  end
 end


### PR DESCRIPTION
## Why
CAMI services will use message queues for 2 way communication instead of APIs which are more like 1 way. RabbitMQ is a popular message queue implementation with clients for many languages.

## What
- [x] write Ansible playbook to set up a RabbitMQ instance
- [ ] set up demo queues
- [ ] set up demo exchange
- [x] set up users and permissions

## Notes
