### PR TITLE
Define state examples for homepage screen

### DIFF
--- a/application/api-examples/homepage/severity.high.json
+++ b/application/api-examples/homepage/severity.high.json
@@ -1,0 +1,7 @@
+{
+  "notification": {
+    "type": "blood_pressure",
+    "severity": "high",
+    "message": "Try to relax, your blood pressure is running wild"
+  }
+}

--- a/application/api-examples/homepage/severity.low.json
+++ b/application/api-examples/homepage/severity.low.json
@@ -1,0 +1,7 @@
+{
+  "notification": {
+    "type": "weight",
+    "severity": "low",
+    "message": "There's a slight increase in your weight since the last measurement"
+  }
+}

--- a/application/api-examples/homepage/severity.medium.json
+++ b/application/api-examples/homepage/severity.medium.json
@@ -1,0 +1,7 @@
+{
+  "notification": {
+    "type": "weight",
+    "severity": "medium",
+    "message": "Your weight loss plan is in danger"
+  }
+}


### PR DESCRIPTION
## Why
We need to decouple UI dev from backend dev and mocking the state allows to do just that.

## What
- [x] add api-examples folder to store state examples
- [x] add examples that showcase all possible values for notification type and severity

## Notes
