### PR TITLE
Caregiver - add summary journal entries to homescreen

### DIFF
--- a/application/src/modules/homepage-caregiver/HomepageView.js
+++ b/application/src/modules/homepage-caregiver/HomepageView.js
@@ -59,6 +59,9 @@ const HomepageView = React.createClass({
             </Text>
 
             <ScrollView style={{flex: 1}}>
+              {/* TODO */}
+              {/* Limit somehow the latest entries count */}
+              {/* Maybe show only for today, or only last 5 */}
               {this.props.events.map((event, index) =>
                 <JournalEntry
                   key={index}

--- a/application/src/modules/homepage-caregiver/HomepageView.js
+++ b/application/src/modules/homepage-caregiver/HomepageView.js
@@ -1,9 +1,10 @@
-import {Map} from 'immutable'
+import {Map, List} from 'immutable'
 import React, {PropTypes} from 'react';
 import {
   StyleSheet,
   Text,
   View,
+  ScrollView,
   Image,
   TouchableOpacity,
   Dimensions,
@@ -12,11 +13,13 @@ import {
 import Color from 'color';
 
 import StatusChart from './components/StatusChart';
+import JournalEntry from './components/JournalEntry';
 
 const HomepageView = React.createClass({
   propTypes: {
-    status: PropTypes.object.isRequired,
-    username: PropTypes.string.isRequired
+    username: PropTypes.string.isRequired,
+    status: PropTypes.instanceOf(Map).isRequired,
+    events: PropTypes.instanceOf(List).isRequired
   },
 
   render() {
@@ -49,6 +52,26 @@ const HomepageView = React.createClass({
               image={require('../../../images/weight-warning.png')}
               unit="kg"/>
           </View>
+
+          <View style={{flex: 1}}>
+            <Text style={[styles.mainText, {fontWeight: 'bold', textAlign: 'center'}]}>
+              Latest Journal Entries
+            </Text>
+
+            <ScrollView style={{flex: 1}}>
+              {this.props.events.map((event, index) =>
+                <JournalEntry
+                  key={index}
+                  type={event.get('type')}
+                  status={event.get('status')}
+                  timestamp={event.get('timestamp')}
+                  title={event.get('title')}
+                />
+              )}
+            </ScrollView>
+
+          </View>
+
         </View>
       </View>
     );

--- a/application/src/modules/homepage-caregiver/HomepageViewContainer.js
+++ b/application/src/modules/homepage-caregiver/HomepageViewContainer.js
@@ -6,5 +6,6 @@ export default connect(
   state => ({
     username: state.getIn(['auth', 'currentUser', 'name']),
     status: state.getIn(['homepageCaregiver']),
+    events: state.getIn(['journal', 'events']),
   })
 )(HomepageView);

--- a/application/src/modules/homepage-caregiver/components/JournalEntry.js
+++ b/application/src/modules/homepage-caregiver/components/JournalEntry.js
@@ -15,8 +15,7 @@ const JournalEntry = React.createClass({
     type: PropTypes.string.isRequired,
     status: PropTypes.string.isRequired,
     timestamp: PropTypes.number.isRequired,
-    title: PropTypes.string.isRequired,
-    message: PropTypes.string.isRequired
+    title: PropTypes.string.isRequired
   },
 
   render() {
@@ -24,17 +23,14 @@ const JournalEntry = React.createClass({
 
     return (
       <View style={{backgroundColor: 'white', flexDirection: 'row'}}>
-        <View style={{flex: 1}}>
-          <View style={{justifyContent: 'center', alignItems: 'center'}}>
-            <Image source={images[this.props.type][this.props.status]}/>
-          </View>
-          <View style={{justifyContent: 'center', alignItems: 'center'}}>
-            <Text>{time}</Text>
-          </View>
+        <View>
+          <Image source={images[this.props.type][this.props.status]}/>
         </View>
-        <View style={{flex: 3, justifyContent: 'center', alignItems: 'center'}}>
+        <View>
+          <Text>{time}</Text>
+        </View>
+        <View style={{flex: 1}}>
           <Text>{this.props.title}</Text>
-          <Text>{this.props.message}</Text>
         </View>
       </View>
     );

--- a/application/src/modules/journal/JournalView.js
+++ b/application/src/modules/journal/JournalView.js
@@ -30,7 +30,7 @@ const JournalView = React.createClass({
     const todayDateText = moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).format(DATE_FORMAT);
     const firstEventDateText = moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).format(DATE_FORMAT);
     const headerDateText = todayDateText == firstEventDateText ? 'Today ' + todayDateText : firstEventDateText;
-    
+
     const events = [];
     let dayKey = firstEventDateText;
     this.props.events.forEach((event, index) => {


### PR DESCRIPTION
## Why
The caregiver needs to get a quick overview of the latest events on the homescreen.

## What
* [x] add latest events json mock for the homescreen
* [x] create homescreen JournalEntry widget
* [x] show the latest journal entries on homescreen

The mockup to be used is:
![cami_caregiver-app_home-tab_v2 3](https://cloud.githubusercontent.com/assets/289455/17219762/2f39d90e-54f5-11e6-8b51-81879205ab1c.jpg)


## Notes
