### PR TITLE
Update mobile app to work with frontend API

### DIFF
--- a/application/index.ios.js
+++ b/application/index.ios.js
@@ -2,7 +2,6 @@ import {Provider} from 'react-redux';
 import store from './src/redux/store';
 import AppViewContainer from './src/modules/AppViewContainer';
 import * as HomepageStateActions from './src/modules/homepage/HomepageState'
-import HomepageViewContainer from './src/modules/homepage/HomepageViewContainer'
 
 import React from 'react';
 import {AppRegistry} from 'react-native';
@@ -11,7 +10,7 @@ const Cami = React.createClass({
 
   render() {
     // Start polling for notifications.
-    // store.dispatch(HomepageStateActions.requestNotification());
+    store.dispatch(HomepageStateActions.requestNotification());
 
     return (
       <Provider store={store}>

--- a/application/src/modules/homepage/HomepageState.js
+++ b/application/src/modules/homepage/HomepageState.js
@@ -24,10 +24,21 @@ export async function requestNotification() {
 }
 
 async function fetchNotification() {
+  var apiUrl = env.NOTIFICATIONS_REST_API;
+
   // Use random parameter to defeat cache.
-  return fetch(env.NOTIFICATIONS_REST_API + '?r=' + Math.floor(Math.random() * 10000))
+  apiUrl += apiUrl.indexOf('?') > -1 ? '&' : '?';
+  apiUrl += 'r=' + Math.floor(Math.random() * 10000);
+
+  return fetch(apiUrl)
     .then((response) => {
-      return response.json()
+      return response.json().then(function(json) {
+        console.log(json);
+        if (json.objects.length == 0) {
+          return initialState.getIn(['notification']);
+        }
+        return json.objects[0];
+      });
     })
     .catch((error) => {
       return initialState.getIn(['notification']);

--- a/application/src/modules/homepage/HomepageState.js
+++ b/application/src/modules/homepage/HomepageState.js
@@ -66,6 +66,7 @@ export default function HomepageStateReducer(state = initialState, action = {}) 
     case NOTIFICATION_RESPONSE:
       // We got a notification update so let's update the state and then restart the timer.
       return loop(
+        // TODO(@iprunache) stop triggering a render for every poll when the payload does not change; happens with immutable too.
         state.set('notification', fromJS(action.payload)),
         Effects.promise(triggerFetchNotification)
       );

--- a/application/src/modules/navigation/NavigationTabView.js
+++ b/application/src/modules/navigation/NavigationTabView.js
@@ -35,6 +35,10 @@ const NavigationTabView = React.createClass({
   },
 
   renderScene(props) {
+    // TODO(@iprunache) find a better place to trigger sounds on navigation
+    // since renderScene is called every time a view is rendered and for the
+    // elder homepage this happens when notifications change.
+
     // play sound on start to load of new scene
     tapButtonSound.setVolume(1.0).play();
 


### PR DESCRIPTION
## Why
Stop using a mock API and use the real API for frontend when polling for the latest notification.

## What
- [x] modify docker-compose recipe to map a static port on the host for the frontend API so the client application can access it.
- [x] update client application to poll frontend API running in a Docker container.

## Notes
