### PR TITLE
Docker-compose file for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,30 @@ http://www.camiproject.eu/
 
 # Setup using Docker
 
-The project now has a Docker containers configured for the microservices. This is still WIP but a functional dev env can be started using Docker.
+The project now has a Docker containers configured for the microservices. You can either run them using the images saved on DockerHub (`Production`) or using the local code (`Development`).
 
 You will need `docker-compose` to get the env running. Follow the [installation guide](https://docs.docker.com/compose/install/).
 
-Once you have `docker-compose` installed just run this from the project root:
+## Run for Production
+
+To run the project using the images from DockerHub (`Production Only` - **this will not use the local code!**), execute the next command:
+
+```
+docker-compose -f docker-compose-prod.yml up
+```
+
+## Run for Development
+
+If you want to open the development environment, you can use the following command from the project's root:
 ```
 docker-compose up
 ```
-This will start all cami microservices and output their standard output. It may take a while for all the containers to come online especially on the first run when the mysql database is initialised on cami-store. To check that all is working try this in your browser: `http://127.0.0.1:8000/api/v1/medication-plans/`. Replace `127.0.0.1` with your VM's ip if you're running Docker in a VM.
 
-Check out frontend notification API at `http://127.0.0.1:8001/api/v1/notifications/?limit=2`.
+This will start all cami microservices and output their standard output. It may take a while for all the containers to come online especially on the first run when the mysql database is initialised on cami-store. To check that all is working try this in your browser: `http://127.0.0.1:8000/api/v1/medication-plans/`. Replace `127.0.0.1` with your VM's ip if you're running Docker in a VM. Check out frontend notification API at `http://127.0.0.1:8001/api/v1/notifications/?limit=2`.
+
+On each change of the code, the app will restart so you can test and develop the app fast. If the code does not reload, simply press Ctrl+C and run again the command.
+
+The docker-compose recipe is set up so that you can use the containers for development. All the containers have the host project folder synced to the `/cami-project` folder from which the microservices are executed. **Any change you do on the host will be reflected in the running apps.**
 
 You can also run the containers as daemons:
 ```
@@ -26,15 +39,6 @@ docker-compose logs
 
 Use `docker-compose stop` to stop the containers or Ctrl+C to stop then when not running as daemon.
 
-If you want to open the development environment, you can use the following command:
-
-```
-docker-compose -f docker-compose-dev.yml up
-```
-
-On each change of the code, the app will restart so you can test and develop the app fast. If the code does not reload, simply press Ctrl+C and run again the command.
-
-The docker-compose recipe is set up so that you can use the containers for development. All containers have the host project folder synced to the `/cami-project` folder from which the microservices are run. **Any change you do on the host will be reflected in the running apps.**
 The next sections are optional and they can be used if you want to run all the components that you are developing separately outside Docker.
 
 ## Components

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,16 +1,12 @@
 version: '2'
 services:
   cami-store:
-    build:
-      context: .
-      dockerfile: Dockerfile-store
+    image: vitaminsoftware/cami-project:store
     ports:
       # Make the store MySQL available on the host so VMs can access it
       - "3307:3306"
   cami-rabbitmq:
-    build:
-      context: .
-      dockerfile: Dockerfile-rabbitmq
+    image: vitaminsoftware/cami-project:rabbitmq
     ports:
       # Make the RabbitMQ server available on the host so VMs can access it
       - "5673:5672"
@@ -18,9 +14,7 @@ services:
   # Run migrations in a separate container from the main applications. The
   # container will just run migrations and load fixtures and then exit.
   cami-medical-compliance-migrate:
-    build:
-      context: .
-      dockerfile: Dockerfile-medical-compliance
+    image: vitaminsoftware/cami-project:medical-compliance
     links:
       - cami-store
     volumes:
@@ -28,9 +22,7 @@ services:
     entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-migration-entrypoint.sh
 
   cami-medical-compliance:
-    build:
-      context: .
-      dockerfile: Dockerfile-medical-compliance
+    image: vitaminsoftware/cami-project:medical-compliance
     links:
       - cami-store
       - cami-rabbitmq
@@ -42,34 +34,27 @@ services:
 
   # Runs the Celery worker for consuming messages received by the medical-compliance
   cami-medical-compliance-message-worker:
-    build:
-      context: .
-      dockerfile: Dockerfile-medical-compliance
+    image: vitaminsoftware/cami-project:medical-compliance
     links:
       # Needs the store to interact with the DB
       - cami-store
       - cami-rabbitmq
     volumes:
       - .:/cami-project
-    entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint-dev.sh
+    entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint.sh
 
   # Run migrations in a separate container from the main applications. The
   # container will just run migrations and load fixtures and then exit.
   cami-frontend-migrate:
-    build:
-      context: .
-      dockerfile: Dockerfile-frontend
+    image: vitaminsoftware/cami-project:frontend
     links:
       - cami-store
     volumes:
       - .:/cami-project
     entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-migration-entrypoint.sh
 
-  # Should use cached image that is build for cami-frontend-migrate
   cami-frontend:
-    build:
-      context: .
-      dockerfile: Dockerfile-frontend
+    image: vitaminsoftware/cami-project:frontend
     links:
       - cami-store
       - cami-rabbitmq
@@ -81,13 +66,11 @@ services:
 
   # Runs the Celery worker for consuming messages received by the frontend
   cami-frontend-message-worker:
-    build:
-      context: .
-      dockerfile: Dockerfile-frontend
+    image: vitaminsoftware/cami-project:frontend
     links:
       # Needs the store to interact with the DB
       - cami-store
       - cami-rabbitmq
     volumes:
       - .:/cami-project
-    entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint-dev.sh
+    entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - cami-rabbitmq
     volumes:
       - .:/cami-project
-    entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint.sh
+    entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint-dev.sh
 
   # Run migrations in a separate container from the main applications. The
   # container will just run migrations and load fixtures and then exit.
@@ -90,4 +90,4 @@ services:
       - cami-rabbitmq
     volumes:
       - .:/cami-project
-    entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint.sh
+    entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint-dev.sh


### PR DESCRIPTION
## Why

The docker-compose file should open the docker instances from DockerHub, that should make the installation of the app easier

## What

Change docker-compose file to load images from DockerHub

## Notes
