### PR TITLE
Deploy Docker-compose production file to Digital Ocean + docs

### DIFF
--- a/Dockerfile-medical-compliance
+++ b/Dockerfile-medical-compliance
@@ -17,6 +17,7 @@ COPY docker/cami-medical-compliance/docker-message-worker-entrypoint-dev.sh /usr
 
 RUN adduser --disabled-password --gecos '' medical_compliance
 RUN chown medical_compliance /cami-project
+RUN chmod a+rw medical_compliance/debug.log
 
 USER medical_compliance
 

--- a/Dockerfile-medical-compliance
+++ b/Dockerfile-medical-compliance
@@ -15,9 +15,10 @@ COPY docker/cami-medical-compliance/docker-migration-entrypoint.sh /usr/local/bi
 COPY docker/cami-medical-compliance/docker-message-worker-entrypoint.sh /usr/local/bin/
 COPY docker/cami-medical-compliance/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
 
+RUN touch /cami-project/medical_compliance/debug.log
+RUN chmod a+rw /cami-project/medical_compliance/debug.log
 RUN adduser --disabled-password --gecos '' medical_compliance
 RUN chown medical_compliance /cami-project
-RUN chmod a+rw medical_compliance/debug.log
 
 USER medical_compliance
 

--- a/application/README.md
+++ b/application/README.md
@@ -6,6 +6,9 @@
 cp env.example.js env.js
 npm install
 ```
+
+`Note`: This will use the Rest API of the backend deployed on Digital Ocean. If you want to link the mobile app with the local REST Api endpoint, just go to the env.js file and replace all the IPs with `127.0.0.1`.
+
 - Go to the ios folder and open the project with **XCode 8** by double clicking on `Cami.xcworkspace`
 - From the Project Navigator, expand Cami > Libraries and click on `RCTWebSocket.xcodeproj`
 - Go to Build Settings, find the **Other Warning Flags** and remove the entries `-Wall` and `-Werror`

--- a/application/env.example.js
+++ b/application/env.example.js
@@ -6,6 +6,6 @@ module.exports = {
   AUTH0_CLIENT_ID: '',
   AUTH0_DOMAIN: '',
   POLL_INTERVAL_MILLIS: 5000,
-  NOTIFICATIONS_REST_API: 'http://127.0.0.1:8001/api/v1/notifications/',
-  WEIGHT_MEASUREMENTS_LAST_VALUES: 'http://127.0.0.1:8000/api/v1/weight-measurements/last_values/'
+  NOTIFICATIONS_REST_API: 'http://139.59.181.210:8001/api/v1/notifications/',
+  WEIGHT_MEASUREMENTS_LAST_VALUES: 'http://139.59.181.210:8000/api/v1/weight-measurements/last_values/'
 };

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -17,8 +17,6 @@ services:
     image: vitaminsoftware/cami-project:medical-compliance
     links:
       - cami-store
-    volumes:
-      - .:/cami-project
     entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-migration-entrypoint.sh
 
   cami-medical-compliance:
@@ -28,8 +26,6 @@ services:
       - cami-rabbitmq
     ports:
       - "8000:8000"
-    volumes:
-      - .:/cami-project
     entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-entrypoint.sh
 
   # Runs the Celery worker for consuming messages received by the medical-compliance
@@ -39,8 +35,6 @@ services:
       # Needs the store to interact with the DB
       - cami-store
       - cami-rabbitmq
-    volumes:
-      - .:/cami-project
     entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint.sh
 
   # Run migrations in a separate container from the main applications. The
@@ -49,8 +43,6 @@ services:
     image: vitaminsoftware/cami-project:frontend
     links:
       - cami-store
-    volumes:
-      - .:/cami-project
     entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-migration-entrypoint.sh
 
   cami-frontend:
@@ -60,8 +52,6 @@ services:
       - cami-rabbitmq
     ports:
       - "8001:8001"
-    volumes:
-      - .:/cami-project
     entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-entrypoint.sh
 
   # Runs the Celery worker for consuming messages received by the frontend
@@ -71,6 +61,4 @@ services:
       # Needs the store to interact with the DB
       - cami-store
       - cami-rabbitmq
-    volumes:
-      - .:/cami-project
     entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint.sh

--- a/docker-compose-rancher.yml
+++ b/docker-compose-rancher.yml
@@ -1,0 +1,73 @@
+cami-store:
+  image: vitaminsoftware/cami-project:store
+  ports:
+    - "3307:3306"
+  tty: true
+  stdin_open: true
+cami-rabbitmq:
+  image: vitaminsoftware/cami-project:rabbitmq
+  ports:
+    - "5673:5672"
+    - "15673:15672"
+  labels:
+    io.rancher.container.pull_image: always
+  tty: true
+  stdin_open: true
+cami-medical-compliance-migrate:
+  image: vitaminsoftware/cami-project:medical-compliance
+  links:
+    - 'cami-store'
+  entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-migration-entrypoint.sh
+  labels:
+    io.rancher.container.pull_image: always
+cami-medical-compliance:
+  image: vitaminsoftware/cami-project:medical-compliance
+  links:
+    - 'cami-store'
+    - 'cami-rabbitmq'
+  ports:
+    - "8000:8000"
+  entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-entrypoint.sh
+  labels:
+    io.rancher.container.pull_image: always
+  tty: true
+  stdin_open: true
+cami-medical-compliance-message-worker:
+  image: vitaminsoftware/cami-project:medical-compliance
+  links:
+    - 'cami-store'
+    - 'cami-rabbitmq'
+  entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint.sh
+  labels:
+    io.rancher.container.pull_image: always
+  tty: true
+  stdin_open: true
+cami-frontend-migrate:
+  image: vitaminsoftware/cami-project:frontend
+  links:
+    - 'cami-store'
+  entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-migration-entrypoint.sh
+  labels:
+    io.rancher.container.pull_image: always
+cami-frontend:
+  image: vitaminsoftware/cami-project:frontend
+  links:
+    - 'cami-store'
+    - 'cami-rabbitmq'
+  ports:
+    - "8001:8001"
+  entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-entrypoint.sh
+  labels:
+    io.rancher.container.pull_image: always
+  tty: true
+  stdin_open: true
+cami-frontend-message-worker:
+  image: vitaminsoftware/cami-project:frontend
+  links:
+    - 'cami-store'
+    - 'cami-rabbitmq'
+  entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint.sh
+  labels:
+    io.rancher.container.pull_image: always
+  tty: true
+  stdin_open: true

--- a/medical_compliance/medical_compliance/settings.py
+++ b/medical_compliance/medical_compliance/settings.py
@@ -162,11 +162,6 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
             'filename': './debug.log',
-        },
-        'celery_file': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': './celery.log',
         }
     },
     'loggers': {
@@ -181,12 +176,12 @@ LOGGING = {
             'propagate': True,
         },
         'withings_controller.save_measurement': {
-            'handlers': ['celery_file'],
+            'handlers': ['file'],
             'level': 'DEBUG',
             'propagate': False,
         },
         'medical_compliance.fetch_weight_measurement': {
-            'handlers': ['celery_file'],
+            'handlers': ['file'],
             'level': 'DEBUG',
             'propagate': False,
         },

--- a/rancher-compose.yml
+++ b/rancher-compose.yml
@@ -1,0 +1,16 @@
+cami-rabbitmq:
+  scale: 1
+cami-store:
+  scale: 1
+cami-medical-compliance-migrate:
+  scale: 1
+cami-medical-compliance:
+  scale: 1
+cami-medical-compliance-message-worker:
+  scale: 1
+cami-frontend-migrate:
+  scale: 1
+cami-frontend:
+  scale: 1
+cami-frontend-message-worker:
+  scale: 1


### PR DESCRIPTION
## Why

Cami should be configured accordingly on Digital Ocean. The server should use the docker-compose file to open the app via rancher.

## What

- [x] Sync cami on the rancher from Digital Ocean
- [x] Document the installation/sync to DO
- [x] Update mobile app's url paths to point to the server on DO

## Notes
