### PR TITLE
Integrate withings subscription call

### DIFF
--- a/application/env.example.js
+++ b/application/env.example.js
@@ -7,5 +7,6 @@ module.exports = {
   AUTH0_DOMAIN: 'vitamin.eu.auth0.com',
   POLL_INTERVAL_MILLIS: 5000,
   NOTIFICATIONS_REST_API: 'http://139.59.181.210:8001/api/v1/notifications/',
-  WEIGHT_MEASUREMENTS_LAST_VALUES: 'http://139.59.181.210:8000/api/v1/weight-measurements/last_values/'
+  WEIGHT_MEASUREMENTS_LAST_VALUES: 'http://139.59.181.210:8000/api/v1/weight-measurements/last_values/',
+  NOTIFICATIONS_SUBSCRIPTION_API: 'http://139.59.181.210:8000/subscribe_notifications/'
 };

--- a/application/src/services/auth0.js
+++ b/application/src/services/auth0.js
@@ -9,6 +9,7 @@ import {redirectToHomePage} from '../modules/navigation/NavigationState';
 const clientId = env.AUTH0_CLIENT_ID;
 const domain = env.AUTH0_DOMAIN;
 const authenticationEnabled = clientId && domain;
+const notificationsSubscriptionApi = env.NOTIFICATIONS_SUBSCRIPTION_API;
 
 let lock = null;
 if (authenticationEnabled) {
@@ -57,5 +58,9 @@ export function showLogin() {
     // Authentication worked!
     store.dispatch(AuthStateActions.onUserLoginSuccess(profile, token));
     store.dispatch(redirectToHomePage(profile.userMetadata.userType));
+
+    fetch(notificationsSubscriptionApi).then((response) => {
+    }).catch((error) => {
+    });
   });
 }


### PR DESCRIPTION
## Why

Right now, Withings has been integrated in the medical compliance project.
The API works in the following way:
- you need to call a Rest API to subscribe for notifications and provide a callback
- the callback is called automatically by withings whenever a new measure appears

The subscription call needs to be integrated somewhere in the flow such as the client, once accessing the app, will receive weight notifications from this API.

## What

Integrate the subscription API Call - the best place is during the login

## Notes
