### PR TITLE
Integrate last journal entries in caregiver home screen

### DIFF
--- a/application/src/modules/homepage-caregiver/HomepageView.js
+++ b/application/src/modules/homepage-caregiver/HomepageView.js
@@ -25,7 +25,7 @@ const HomepageView = React.createClass({
   propTypes: {
     username: PropTypes.string.isRequired,
     status: PropTypes.instanceOf(Map).isRequired,
-    events: PropTypes.instanceOf(List).isRequired,
+    lastEvents: PropTypes.instanceOf(List).isRequired,
     actionability: PropTypes.instanceOf(Map).isRequired,
     dispatch: PropTypes.func.isRequired
   },
@@ -97,7 +97,7 @@ const HomepageView = React.createClass({
               {/* TODO */}
               {/* Limit somehow the latest entries count */}
               {/* Maybe show only for today, or only last 5 */}
-              {this.props.events.map((event, index) =>
+              {this.props.lastEvents.map((event, index) =>
                 <JournalEntry
                   key={index}
                   type={event.get('type')}

--- a/application/src/modules/homepage-caregiver/HomepageViewContainer.js
+++ b/application/src/modules/homepage-caregiver/HomepageViewContainer.js
@@ -7,6 +7,6 @@ export default connect(
     username: state.getIn(['auth', 'currentUser', 'name']),
     status: state.getIn(['homepageCaregiver', 'status']),
     actionability: state.getIn(['homepageCaregiver', 'actionability']),
-    events: state.getIn(['journal', 'events']),
+    lastEvents: state.getIn(['homepageCaregiver', 'lastEvents']),
   })
 )(HomepageView);


### PR DESCRIPTION
## Why

Right now, the caregiver's home screen contains some hardcoded values that represent the last journal entries.
There is a REST Api that has the option the get the last 5/10 notifications, and should be integrated here.

## What

Integrate notifications API with the last 5 or 10 notifications

## Notes
