### PR TITLE
Integrate journal Rest API in Journal Tab with lazy loading

### DIFF
--- a/application/src/modules/homepage-caregiver/HomepageState.js
+++ b/application/src/modules/homepage-caregiver/HomepageState.js
@@ -64,8 +64,7 @@ async function fetchPageData() {
           message: receivedNotification.message,
           description: receivedNotification.description
         }
-        for (var i = 1; i < notificationList.length; i++) {
-          var notification = notificationList[i];
+        notificationList.forEach((notification) => {
           result.lastEvents.push({
             type: notification.type,
             status: notification.severity,
@@ -73,7 +72,7 @@ async function fetchPageData() {
             title: notification.message,
             message: notification.description
           });
-        }
+        });
         result.hasNotification = true;
       }
       var apiUrl = env.WEIGHT_MEASUREMENTS_LAST_VALUES;

--- a/application/src/modules/journal/JournalState.js
+++ b/application/src/modules/journal/JournalState.js
@@ -1,22 +1,62 @@
 // import Promise from 'bluebird';
-import {fromJS} from 'immutable';
+import {fromJS, Map} from 'immutable';
 // import {loop, Effects} from 'redux-loop';
 
-// import * as env from '../../../env';
-
-var json = require('../../../api-examples/journal/eldery-journal.json');
+import * as env from '../../../env';
 
 // Initial state
-const initialState = fromJS(json);
+const initialState = Map({
+  events: fromJS([]),
+  refreshing: false
+});
 
-// Actions
-// const DUMMY_ACTION = 'HomepageState/DUMMY_ACTION';
+const JOURNAL_DATA_RESPONSE = 'JournalState/JOURNAL_DATA_RESPONSE';
+const START_REFRESHING = 'JournalState/START_REFRESHING';
 
-// Action creators
+export function markStartRefreshing() {
+  return {
+    type: START_REFRESHING
+  };
+}
+
+export async function requestJournalData() {
+  return {
+    type: JOURNAL_DATA_RESPONSE,
+    payload: await fetchPageData()
+  };
+}
+async function fetchPageData() {
+  var notificationsUrl = env.NOTIFICATIONS_REST_API + "?recipient_type=caregiver&limit=30&offset=0";
+  notificationsUrl += '&r=' + Math.floor(Math.random() * 10000);
+
+  return fetch(notificationsUrl)
+    .then((response) => response.json())
+    .then((notificationJson) => {
+      var notifications = [];
+      var notificationJsonList = notificationJson.objects;
+      notificationJsonList.forEach((notification) => {
+        notifications.push({
+          type: notification.type,
+          status: notification.severity,
+          timestamp: parseInt(notification.timestamp),
+          title: notification.message,
+          message: notification.description
+        });
+      });
+      return notifications;
+    }).catch((error) => {
+      return [];
+    });
+}
 
 // Reducer
 export default function JournalStateReducer(state = initialState, action = {}) {
   switch (action.type) {
+    case START_REFRESHING:
+      return state.setIn(['refreshing'], true);
+    case JOURNAL_DATA_RESPONSE:
+      return state.setIn(['refreshing'], false)
+          .setIn(['events'], fromJS(action.payload))
     default:
       return state;
   }

--- a/application/src/modules/journal/JournalView.js
+++ b/application/src/modules/journal/JournalView.js
@@ -8,13 +8,15 @@ import {
   Image,
   TouchableOpacity,
   Dimensions,
-  Component
+  Component,
+  RefreshControl
 } from 'react-native';
 import Color from 'color';
 import moment from 'moment';
 
 import JournalEntry from './components/JournalEntry';
 import variables from '../variables/CaregiverGlobalVariables';
+import * as JournalStateActions from './JournalState'
 
 const DATE_FORMAT = 'D MMM';
 const WEEK_DATE_FORMAT = 'ddd D MMM';
@@ -22,15 +24,23 @@ const WEEK_DATE_FORMAT = 'ddd D MMM';
 const JournalView = React.createClass({
   propTypes: {
     events: PropTypes.instanceOf(List).isRequired,
-    username: PropTypes.string.isRequired
+    username: PropTypes.string.isRequired,
+    refreshing: PropTypes.bool.isRequired,
+    dispatch: PropTypes.func.isRequired
+  },
+  componentDidMount() {
+    this.onRefresh();  
+  },
+
+  onRefresh() {
+    this.props.dispatch(JournalStateActions.markStartRefreshing());
+    this.props.dispatch(JournalStateActions.requestJournalData());
   },
 
   render() {
-    // TODO switch places the following 2 lines
-    // const todayDateText = moment().format(DATE_FORMAT);
-    const todayDateText = moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).format(DATE_FORMAT);
-    const firstEventDateText = moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).format(DATE_FORMAT);
-    const headerDateText = todayDateText == firstEventDateText ? 'Today ' + todayDateText : firstEventDateText;
+    const todayDateText = (this.props.events.length > 0) ? moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).format(DATE_FORMAT) : '';
+    const firstEventDateText = (this.props.events.length > 0) ? moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).format(DATE_FORMAT) : '';
+    const headerDateText = (this.props.events.length > 0) ? (todayDateText == firstEventDateText ? 'Today ' + todayDateText : firstEventDateText) : '';
 
     const events = [];
     let dayKey = firstEventDateText;
@@ -69,7 +79,15 @@ const JournalView = React.createClass({
 
         <View style={styles.timeline}></View>
 
-        <ScrollView style={styles.journalContainer}>
+        <ScrollView 
+            style={styles.journalContainer}
+            refreshControl={
+              <RefreshControl
+                refreshing={this.props.refreshing}
+                onRefresh={this.onRefresh}
+                />
+            }
+            >
           {events}
         </ScrollView>
       </View>

--- a/application/src/modules/journal/JournalViewContainer.js
+++ b/application/src/modules/journal/JournalViewContainer.js
@@ -6,5 +6,6 @@ export default connect(
   state => ({
     username: state.getIn(['auth', 'currentUser', 'name']),
     events: state.getIn(['journal', 'events']),
+    refreshing: state.getIn(['journal', 'refreshing']),
   })
 )(JournalView);

--- a/application/src/modules/journal/components/JournalEntry.js
+++ b/application/src/modules/journal/components/JournalEntry.js
@@ -97,7 +97,7 @@ const JournalEntry = React.createClass({
             <Text style={styles.time}>{time}</Text>
           </View>
           <View style={[styles.statusIcon, {backgroundColor: variables.colors.status[this.props.status]}]}>
-            <Icon name={icons[this.props.status]} size={12} color={'white'}/>
+            <Icon name={icons[this.props.type]} size={12} color={'white'}/>
           </View>
         </View>
         <View style={{flex: 7, borderLeftWidth: 2, borderColor: variables.colors.status[this.props.status]}}>

--- a/application/src/modules/variables/CaregiverGlobalVariables.js
+++ b/application/src/modules/variables/CaregiverGlobalVariables.js
@@ -9,7 +9,10 @@ const colors = {
     warning: '#D2B52E',
     ok: '#658d51',
     wakeup: '#658d51',
-    alert: '#c23f21'
+    alert: '#c23f21',
+    low: '#658d51',
+    medium: '#658d51',
+    high: '#c23f21'
   },
   gray: {
     darkest: '#212121',


### PR DESCRIPTION
## Why

Right now, the caregiver's Journal Tab contains hardcoded entries from a local file. These should be replace with the entries returned from the REST API.

## What

The caregiver's Journal tab should contain all the notifications read from the server and should use lazy loading because their number can become huge over time. 

- [ ] Integrate notifications API in the journal screen
- [ ] Add lazy loading on client

## Notes