### PR TITLE
Adapt the design of auth0 login screen to match current app

### DIFF
--- a/application/src/icons-fa.json
+++ b/application/src/icons-fa.json
@@ -6,6 +6,8 @@
   "blood": "tint",
   "steps": "male",
   "warning": "exclamation",
+  "medium": "exclamation",
+  "low": "check",
   "ok": "check",
   "wakeup": "check",
   "plus": "plus",

--- a/application/src/modules/homepage-caregiver/HomepageView.js
+++ b/application/src/modules/homepage-caregiver/HomepageView.js
@@ -42,7 +42,7 @@ const HomepageView = React.createClass({
           <View style={styles.headerContainerInner}>
             <Image style={styles.avatar} source={require('../../../images/old-man.jpg')}/>
             <View style={styles.headerTextContainer}>
-              <Text style={[styles.headerText, {fontWeight: 'bold'}]}>{this.props.username + '\'s'}</Text>
+              <Text style={[styles.headerText, {fontWeight: 'bold'}]}>{'Jim' + '\'s'}</Text>
               <Text style={[styles.headerText, {fontSize: 18}]}>doing fine</Text>
             </View>
           </View>

--- a/application/src/modules/homepage-caregiver/HomepageView.js
+++ b/application/src/modules/homepage-caregiver/HomepageView.js
@@ -74,6 +74,7 @@ const HomepageView = React.createClass({
                 icon={icons.heart}
                 unit="bpm"
                 status="ok"
+                decimals={0}
               />
 
               <StatusChart
@@ -82,6 +83,7 @@ const HomepageView = React.createClass({
                 icon={icons.weight}
                 unit="kg"
                 status={this.props.status.get('values').get('weight').get('status')}
+                decimals={2}
               />
             </View>
           :

--- a/application/src/modules/homepage-caregiver/HomepageView.js
+++ b/application/src/modules/homepage-caregiver/HomepageView.js
@@ -39,11 +39,26 @@ const HomepageView = React.createClass({
 
         <View style={styles.headerContainer}>
           <Image style={styles.headerBackgroundImage} source={require('../../../images/old-man.jpg')}/>
-          <View style={styles.headerContainerInner}>
+          <View
+            style={[
+              styles.headerContainerInner,
+              {
+                backgroundColor: !this.props.actionability.get('visible')
+                  ? Color(variables.colors.status.ok).clearer(.1).rgbaString()
+                  : Color(variables.colors.status.alert).clearer(.1).rgbaString()
+              }
+            ]}
+          >
             <Image style={styles.avatar} source={require('../../../images/old-man.jpg')}/>
             <View style={styles.headerTextContainer}>
-              <Text style={[styles.headerText, {fontWeight: 'bold'}]}>{'Jim' + '\'s'}</Text>
-              <Text style={[styles.headerText, {fontSize: 18}]}>doing fine</Text>
+              <Text style={[styles.headerText, {fontWeight: 'bold'}]}>{'Jim'}</Text>
+              <Text style={[styles.headerText, {fontSize: 18}]}>
+                {
+                  !this.props.actionability.get('visible')
+                    ? 'is doing fine'
+                    : 'needs help'
+                }
+              </Text>
             </View>
           </View>
         </View>
@@ -133,7 +148,6 @@ const styles = StyleSheet.create({
   headerContainerInner: {
     flex: 1,
     justifyContent: 'center',
-    backgroundColor: Color(variables.colors.status.ok).clearer(.1).rgbaString(),
     width: variables.dimensions.width,
     paddingTop: 20
   },

--- a/application/src/modules/homepage-caregiver/components/ActionabilityWidget.js
+++ b/application/src/modules/homepage-caregiver/components/ActionabilityWidget.js
@@ -87,7 +87,7 @@ const ActionabilityWidget = React.createClass({
           </View>
           <View style={{flex: 3, alignItems: 'flex-start', justifyContent: 'center'}}>
             <Text style={[{fontSize: 14}]}>{this.props.message}</Text>
-            <Text style={[{fontSize: 14, marginTop: 10}]}>{this.props.description}</Text>
+            <Text style={[{fontSize: 14, marginTop: 10, paddingRight: 20}]}>{this.props.description}</Text>
           </View>
         </View>
         <View style={{flexDirection: 'row', flex: 1}}>
@@ -96,21 +96,21 @@ const ActionabilityWidget = React.createClass({
             onPress={this.call911}
           >
             <Icon name={icons.plus} size={16} color="white"/>
-            <Text style={[{fontSize: 14, color: "white", fontWeight: 'bold'}]}>Call 911</Text>
+            <Text style={[{fontSize: 14, color: "white", fontWeight: 'bold', paddingTop: 5}]}>Call 911</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={{flex: 2, alignItems: 'center', justifyContent: 'center', backgroundColor: variables.colors.status.ok}}
             onPress={this.callElderly}
           >
             <Icon name={icons.phone} size={16} color="white"/>
-            <Text style={[{fontSize: 14, color: "white", fontWeight: 'bold'}]}>Call {this.props.name}</Text>
+            <Text style={[{fontSize: 14, color: "white", fontWeight: 'bold', paddingTop: 5}]}>Call {this.props.name}</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={{flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: variables.colors.gray.neutral}}
             onPress={this.cancel}
           >
             <Icon name={icons.cancel} size={16} color="white"/>
-            <Text style={[{fontSize: 14, color: "white", fontWeight: 'bold'}]}>Cancel</Text>
+            <Text style={[{fontSize: 14, color: "white", fontWeight: 'bold', paddingTop: 5}]}>Dismiss</Text>
           </TouchableOpacity>
         </View>
       </Animated.View>

--- a/application/src/modules/homepage-caregiver/components/StatusChart.js
+++ b/application/src/modules/homepage-caregiver/components/StatusChart.js
@@ -59,7 +59,8 @@ const StatusChart = React.createClass({
     data: PropTypes.instanceOf(List).isRequired,
     unit: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
-    status: PropTypes.string.isRequired
+    status: PropTypes.string.isRequired,
+    decimals: PropTypes.number
   },
 
   render() {
@@ -75,7 +76,11 @@ const StatusChart = React.createClass({
           </View>
           <View style={chartStyles.infoContainer}>
             <Text style={chartStyles.value}>
-              {currentValue} <Text style={chartStyles.unit}>{this.props.unit}</Text>
+              {
+                this.props.decimals > 0
+                  ? currentValue.toFixed(this.props.decimals)
+                  : currentValue
+              } <Text style={chartStyles.unit}>{this.props.unit}</Text>
             </Text>
             <Text style={chartStyles.description}>{this.props.text}</Text>
           </View>

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -69,7 +69,7 @@ const HomepageView = React.createClass({
         >
           <View style={styles.textContainer}>
             <Text style={[styles.text, {fontWeight: 'bold'}]}>
-              Hey {this.props.username}
+              Hey Jim
             </Text>
             <Text style={[styles.text, {paddingTop: 20}]}>
               {this.props.notification.get("message")}

--- a/application/src/modules/journal/components/JournalEntry.js
+++ b/application/src/modules/journal/components/JournalEntry.js
@@ -97,7 +97,7 @@ const JournalEntry = React.createClass({
             <Text style={styles.time}>{time}</Text>
           </View>
           <View style={[styles.statusIcon, {backgroundColor: variables.colors.status[this.props.status]}]}>
-            <Icon name={icons[this.props.type]} size={12} color={'white'}/>
+            <Icon name={icons[this.props.status]} size={12} color={'white'}/>
           </View>
         </View>
         <View style={{flex: 7, borderLeftWidth: 2, borderColor: variables.colors.status[this.props.status]}}>

--- a/application/src/modules/login/LoginView.js
+++ b/application/src/modules/login/LoginView.js
@@ -2,28 +2,15 @@ import {Map} from 'immutable'
 import React, {PropTypes} from 'react';
 import {
   StyleSheet,
-  Text,
   View,
-  Image,
-  TouchableOpacity
+  Image
 } from 'react-native';
 
-import LoginInput from './components/LoginInput';
-
-import Icon from 'react-native-vector-icons/FontAwesome';
-import icons from 'Cami/src/icons-fa';
 import variables from 'Cami/src/modules/variables/ElderGlobalVariables';
 
 import * as LoginState from './LoginState';
 
 var Color = require("color");
-
-var Sound = require('react-native-sound');
-var tapButtonSound = new Sound('sounds/knuckle.mp3', Sound.MAIN_BUNDLE, (error) => {
-  if (error) {
-    console.log('failed to load the sound', error);
-  }
-});
 
 const LoginView = React.createClass({
   render() {
@@ -42,58 +29,10 @@ const LoginView = React.createClass({
             }
           ]}
           />
-        <View style={styles.headerContainer}>
-          <View style={styles.iconContainer}>
-            <Icon
-              name={icons.heart_solid}
-              size={80}
-              color={Color('white').clearer(.25).rgbaString()}
-              />
-          </View>
-          <Text style={styles.greeting}>Welcome</Text>
-        </View>
-
-        <View style={styles.mainContainer}>
-          <View style={styles.formContainer}>
-            <LoginInput
-              placeholder="Username"
-              icon="user"
-              secureTextEntry={false}
-              name="username"
-              />
-            <LoginInput
-              placeholder="Password"
-              icon="password"
-              secureTextEntry={true}
-              name="password"
-              />
-          </View>
-          <TouchableOpacity
-            style={[
-              styles.button,
-              styles.buttonConfirm,
-              {
-                shadowColor: Color(variables.colors.status.low).darken(.8).hexString()
-              }
-            ]}
-            onPress={this.logIn}
-            >
-            <Text style={styles.buttonText}>
-              LOGIN
-            </Text>
-          </TouchableOpacity>
-        </View>
       </View>
     );
   }
 });
-
-const buttonCircle = {
-  borderWidth: 0,
-  borderRadius: 45,
-  width: 90,
-  height: 90
-};
 
 const styles = StyleSheet.create({
   background: {
@@ -104,56 +43,7 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     alignSelf: 'center',
-  },
-  headerContainer: {
-    flex: 1,
-    zIndex: 5,
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    paddingTop: 20,
-    backgroundColor: 'transparent'
-  },
-  iconContainer: {
-    backgroundColor: 'transparent',
-    marginBottom: 30
-  },
-  greeting: {
-    fontSize: 28,
-    color: Color('white').clearer(.1).rgbaString(),
-    backgroundColor: 'transparent'
-  },
-  mainContainer: {
-    flex: 2,
-    alignItems: 'center',
-    zIndex: 4,
-    backgroundColor: 'transparent',
-    marginTop: 50
-  },
-  formContainer: {
-    marginBottom: 30
-  },
-  buttonContainer: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center'
-  },
-  button: {
-    ...buttonCircle,
-  alignSelf: 'center',
-  justifyContent: 'center',
-  shadowRadius: 40,
-  shadowOffset: {width: 0, height: 0},
-  shadowOpacity: 0.5,
-  backgroundColor: 'white'
-  },
-buttonText: {
-  backgroundColor: 'transparent',
-    textAlign: 'center',
-      alignSelf: 'center',
-        fontSize: 16,
-          fontWeight: 'bold',
-            color: Color(variables.colors.status.low).clearer(.05).rgbaString()
-}
+  }
 });
 
 export default LoginView;

--- a/application/src/modules/status/components/StatusEntry.js
+++ b/application/src/modules/status/components/StatusEntry.js
@@ -28,9 +28,9 @@ const config = {
     highlightPerTap: false,
     highlightValues: false,
     drawHorizontalHighlightIndicator: false,
-    drawVerticalHighlightIndicator: false,
+    drawVerticalHighlightIndicator: false
   }],
-  backgroundColor: 'blue',
+  backgroundColor: '#ffffff',
   // minOffset: 20,
   scaleYEnabled: false,
   legend: {
@@ -104,7 +104,7 @@ const StatusEntry = React.createClass({
     dataSet.circleColors = [];
     this.props.data.forEach(item => {
       chartConfig.labels.push(this.formatTimestamp(item.get('timestamp')));
-      
+
       var value = formatValue(item.get('status'), item.get('value'), this.props.threshold);
       if(this.props.type == 'weight') {
         value = item.get('value');

--- a/application/src/modules/variables/CaregiverGlobalVariables.js
+++ b/application/src/modules/variables/CaregiverGlobalVariables.js
@@ -11,7 +11,7 @@ const colors = {
     wakeup: '#658d51',
     alert: '#c23f21',
     low: '#658d51',
-    medium: '#658d51',
+    medium: '#D2B52E',
     high: '#c23f21'
   },
   gray: {

--- a/application/src/services/auth0.js
+++ b/application/src/services/auth0.js
@@ -4,6 +4,9 @@ import * as AuthStateActions from '../modules/auth/AuthState';
 import store from '../redux/store';
 const {Platform} = require('react-native');
 
+import Color from 'color';
+import variables from '../modules/variables/ElderGlobalVariables';
+
 import {redirectToHomePage} from '../modules/navigation/NavigationState';
 
 const clientId = env.AUTH0_CLIENT_ID;
@@ -34,17 +37,18 @@ export function showLogin() {
 
   if (Platform.OS === 'ios') {
     lock.customizeTheme({
-      A0ThemePrimaryButtonNormalColor: '#39babd',
-      A0ThemePrimaryButtonHighlightedColor: '#08AFB3',
-      A0ThemeSecondaryButtonTextColor: '#ffffff',
-      A0ThemeTextFieldTextColor: '#ffffff',
-      A0ThemeTextFieldPlaceholderTextColor: '#ffffff',
-      A0ThemeTextFieldIconColor: '#ffffff',
-      A0ThemeTitleTextColor: '#ffffff',
-      A0ThemeDescriptionTextColor: '#ffffff',
-      A0ThemeSeparatorTextColor: '#ffffff',
-      A0ThemeScreenBackgroundColor: '#39babd',
-      A0ThemeIconImageName: 'pepperoni',
+      A0ThemePrimaryButtonNormalColor: variables.colors.status.low,
+      A0ThemePrimaryButtonHighlightedColor: Color(variables.colors.status.low).darken(.25).hexString(),
+      A0ThemeSecondaryButtonTextColor: variables.colors.gray.dark,
+      A0ThemeTextFieldTextColor: variables.colors.gray.dark,
+      A0ThemeTextFieldPlaceholderTextColor: variables.colors.gray.neutral,
+      A0ThemeTextFieldIconColor: variables.colors.status.low,
+      A0ThemeTitleTextColor: variables.colors.gray.dark,
+      A0ThemeDescriptionTextColor: variables.colors.gray.dark,
+      A0ThemeSeparatorTextColor: variables.colors.gray.light,
+      A0ThemeScreenBackgroundColor: variables.colors.gray.lightest,
+      A0ThemeIconBackgroundColor: variables.colors.gray.lightest,
+      A0ThemeIconImageName: '',
       A0ThemeCredentialBoxBorderColor: '' //transparent
     });
   }


### PR DESCRIPTION
## Why
As a user of the CAMI system, I must authenticate using Username/Password before I have access to the app and information presented within. Also based on my credentials, I will be either redirected to the Elder or Caregiver side of the app.

---

The integration of the auth0 system in #74 for the login functionality of the App, came with a pre-built Login screen that not only looks good, but also has "Reset Password" functionality and error notifications for the form.

This makes the Login in #64 no longer relevant. As such, the best course of action for a speedy and closer integration of auth0 w/ the current app, is to adapt it, best-effort, to our use case.

![current pre-built design of the auth0 login screen](http://mq.d.pr/11rLg.jpg)

## What
* [x] the design of the auth0 login screen is adapted to the existing desing, taking into account:
   * [x] the in-house Login screen built in #64 and tweaked in #71, is simplified to be just a background container on top of which the auth0 interface will be included
      * this way, it will act as a splash screen for the intermidiary loading stages of auth0 interface
   * [x] the interface is adapted to match the established color scheme
* [x] after signing in, the current user's name is displayed appropriately inside the Caregiver & Elder interfaces

## Notes
