### PR TITLE
Map IP to cami.vitaminsoftware.com

### DIFF
--- a/application/env.example.js
+++ b/application/env.example.js
@@ -6,7 +6,7 @@ module.exports = {
   AUTH0_CLIENT_ID: 'xqN8fSjHL6850gI2m8AUkk5GICgvTCUs',
   AUTH0_DOMAIN: 'vitamin.eu.auth0.com',
   POLL_INTERVAL_MILLIS: 5000,
-  NOTIFICATIONS_REST_API: 'http://139.59.181.210:8001/api/v1/notifications/',
-  WEIGHT_MEASUREMENTS_LAST_VALUES: 'http://139.59.181.210:8000/api/v1/weight-measurements/last_values/',
-  NOTIFICATIONS_SUBSCRIPTION_API: 'http://139.59.181.210:8000/subscribe_notifications/'
+  NOTIFICATIONS_REST_API: 'http://cami.vitaminsoftware.com:8001/api/v1/notifications/',
+  WEIGHT_MEASUREMENTS_LAST_VALUES: 'http://cami.vitaminsoftware.com:8000/api/v1/weight-measurements/last_values/',
+  NOTIFICATIONS_SUBSCRIPTION_API: 'http://cami.vitaminsoftware.com:8000/subscribe_notifications/'
 };


### PR DESCRIPTION
## Why

The client (in this case a mobile app) has a settings file that contains the URL of the backend services. 
Right now, this contains a static IP which needs to be changed with a hostname as it can change over time, and all the users would need to reinstall the app in this case.

## What

Add DNS setting that will map `cami.vitaminsoftware.com` to the actual Rancher's IP and add it to the settings file

## Notes
