### PR TITLE
Integrate Logout button on Elder's home screen

### DIFF
--- a/application/src/icons-fa.json
+++ b/application/src/icons-fa.json
@@ -20,5 +20,6 @@
   "right": "chevron-right",
   "camera": "video-camera",
   "tv": "television",
-  "smartphone": "mobile"
+  "smartphone": "mobile",
+  "logout": "sign-out"
 }

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -48,6 +48,18 @@ const HomepageView = React.createClass({
           source={require('../../../images/elder-mainContent-bg.png')}
         />
         <View style={styles.iconContainer}>
+          <View style={styles.logoutButtonContainer}>
+            <TouchableOpacity
+              style={styles.logoutButton}
+              onPress={() => tapButtonSound.setVolume(1.0).play()}
+            >
+              <Icon
+                name={icons.logout}
+                size={16}
+                color={Color('white').clearer(.25).rgbaString()}
+              />
+            </TouchableOpacity>
+          </View>
           <View style={styles.outerRing}>
             <View style={styles.iconRing}>
               <Icon
@@ -139,7 +151,14 @@ const styles = StyleSheet.create({
     zIndex: 5,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingTop: 20
+    paddingTop: 20,
+    position: 'relative'
+  },
+  logoutButtonContainer: {
+    position: 'absolute',
+    top: 25,
+    left: 20,
+    backgroundColor: 'transparent'
   },
   outerRing: {
     borderWidth: 2,

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -24,7 +24,8 @@ var tapButtonSound = new Sound('sounds/knuckle.mp3', Sound.MAIN_BUNDLE, (error) 
 const HomepageView = React.createClass({
   propTypes: {
     notification: PropTypes.instanceOf(Map).isRequired,
-    username: PropTypes.string.isRequired
+    username: PropTypes.string.isRequired,
+    logout: PropTypes.func.isRequired
   },
 
   render() {
@@ -51,7 +52,7 @@ const HomepageView = React.createClass({
           <View style={styles.logoutButtonContainer}>
             <TouchableOpacity
               style={styles.logoutButton}
-              onPress={() => tapButtonSound.setVolume(1.0).play()}
+              onPress={() => tapButtonSound.setVolume(1.0).play() && this.props.logout()}
             >
               <Icon
                 name={icons.logout}

--- a/application/src/modules/homepage/HomepageViewContainer.js
+++ b/application/src/modules/homepage/HomepageViewContainer.js
@@ -1,10 +1,18 @@
 import {connect} from 'react-redux';
 
 import HomepageView from './HomepageView';
+import {redirectToLoginPage} from '../navigation/NavigationState';
+import {logout} from '../auth/AuthState';
 
 export default connect(
   state => ({
     notification: state.getIn(['homepage', 'notification']),
     username: state.getIn(['auth', 'currentUser', 'name'])
+  }),
+  dispatch => ({
+    logout() {
+      dispatch(logout());
+      dispatch(redirectToLoginPage());
+    }
   })
 )(HomepageView);


### PR DESCRIPTION
## Why
Right now, if a user wants to logout of the Elder's application screen he has to delete and then reinstall the app. There has to be a more user-friendly approach to doing so, taking into account that the App can only be reinstalled by connecting the phone to a computer.

## What
* [x] a logout button is implemented in the Elder's home screen design, taking into account a placement that will prevent accidental presses
* [x] pressing the button logs out the elder and returns him to the login screen

## Notes
