### PR TITLE
Papertrail integration for programmatic logs

### DIFF
--- a/LOGGING.md
+++ b/LOGGING.md
@@ -1,0 +1,33 @@
+Application logs
+=========================================
+### Configure Papertrail logging
+1. Django apps
+In the application's ```settings.py``` file a new logging handler needs to be added:
+
+```
+'syslog': {
+    'level':'DEBUG',
+    'class':'logging.handlers.SysLogHandler',
+    'formatter': 'verbose',
+    'address':(PAPERTRAILS_LOGGING_HOSTNAME, PAPERTRAILS_LOGGING_PORT)
+}
+```
+Add this new handler, ```syslog```, to all the loggers you would like to redirect also to Papertrail.
+
+2. Plain Python apps
+Alos the SysLogHandler is used to redirect logs to Papertrail.
+The snippet below configures the Python logger to send logs to Papertrail:
+```
+import logging
+from logging.handlers import SysLogHandler
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+syslog = SysLogHandler(address=(PAPERTRAILS_LOGGING_HOSTNAME, PAPERTRAILS_LOGGING_PORT))
+formatter = logging.Formatter('%(levelname)s %(asctime)s %(module)s '
+                      '%(process)d %(thread)d %(message)s')
+
+syslog.setFormatter(formatter)
+logger.addHandler(syslog)
+```

--- a/frontend/api/tasks.py
+++ b/frontend/api/tasks.py
@@ -30,7 +30,7 @@ app.conf.update(
 
 @celery.task(name='frontend.send_notification')
 def send_notification(user_id, recipient_type, type, severity, message, description, timestamp):
-    logger.debug("Send notification request: { user_id: %s, recipient_type: %s, type: %s, severity: %s, message: %s, description: %s, timestamp: %s}" 
+    logger.debug("[frontend] Send notification request: { user_id: %s, recipient_type: %s, type: %s, severity: %s, message: %s, description: %s, timestamp: %s}" 
         % (user_id, recipient_type, type, severity, message, description, timestamp))
 
     if timestamp is None:

--- a/frontend/api/tasks.py
+++ b/frontend/api/tasks.py
@@ -18,7 +18,7 @@ from push_notifications.models import APNSDevice
 
 from models import Notification
 
-logger = get_task_logger(__name__)
+logger = get_task_logger('frontend.tasks')
 
 app = Celery('api.tasks', broker=settings.BROKER_URL)
 app.conf.update(
@@ -30,6 +30,9 @@ app.conf.update(
 
 @celery.task(name='frontend.send_notification')
 def send_notification(user_id, recipient_type, type, severity, message, description, timestamp):
+    logger.debug("Send notification request: { user_id: %s, recipient_type: %s, type: %s, severity: %s, message: %s, description: %s, timestamp: %s}" 
+        % (user_id, recipient_type, type, severity, message, description, timestamp))
+
     if timestamp is None:
         timestamp = time.time()
     n = Notification(user_id=user_id, recipient_type=recipient_type, type=type, severity=severity, timestamp=timestamp, message=message, description=description)

--- a/frontend/frontend/settings.py
+++ b/frontend/frontend/settings.py
@@ -85,6 +85,8 @@ RAVEN_CONFIG = {
     'release': raven.fetch_git_sha(os.path.dirname(__file__) + "/../../")
 }
 
+PAPERTRAILS_LOGGING_HOSTNAME = 'logs4.papertrailapp.com'
+PAPERTRAILS_LOGGING_PORT = 43843
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,
@@ -103,16 +105,22 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'
-        }
+        },
+        'syslog': {
+            'level':'DEBUG',
+            'class':'logging.handlers.SysLogHandler',
+            'formatter': 'verbose',
+            'address':(PAPERTRAILS_LOGGING_HOSTNAME, PAPERTRAILS_LOGGING_PORT)
+        },
     },
     'loggers': {
         'frontend': {
             'level': 'DEBUG',
-            'handlers': ['sentry', 'console'],
+            'handlers': ['sentry', 'console', 'syslog'],
         },
         'api': {
             'level': 'DEBUG',
-            'handlers': ['sentry', 'console'],
+            'handlers': ['sentry', 'console', 'syslog'],
         },
         'django': {
             'level': 'DEBUG',
@@ -136,7 +144,7 @@ LOGGING = {
         'celery': {
             'level': 'ERROR',
             'handlers': ['sentry', 'console'],
-        }
+        },
     },
 }
 

--- a/frontend/frontend/settings.py
+++ b/frontend/frontend/settings.py
@@ -145,6 +145,10 @@ LOGGING = {
             'level': 'ERROR',
             'handlers': ['sentry', 'console'],
         },
+        'frontend.tasks': {
+            'level': 'DEBUG',
+            'handlers': ['sentry', 'console', 'syslog'],
+        },
     },
 }
 

--- a/linkwatch/custom_logging.py
+++ b/linkwatch/custom_logging.py
@@ -1,0 +1,14 @@
+import logging
+import settings
+
+from logging.handlers import SysLogHandler
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+syslog = SysLogHandler(address=(settings.PAPERTRAILS_LOGGING_HOSTNAME, settings.PAPERTRAILS_LOGGING_PORT))
+formatter = logging.Formatter('%(levelname)s %(asctime)s %(module)s '
+                      '%(process)d %(thread)d %(message)s')
+
+syslog.setFormatter(formatter)
+logger.addHandler(syslog)

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -1,14 +1,11 @@
 import requests
 import urlparse
 import json
-import logging
 import datetime, pytz
 import constants
-from settings import *
 
-logging.basicConfig()
-logger = logging.getLogger(name="endpoints")
-logger.setLevel(logging.INFO)
+from custom_logging import logger
+from settings import *
 
 class EndpointResult(object):
     '''
@@ -190,14 +187,14 @@ def save_measurement(measurement_json):
     login_endpoint = LoginEndpoint(LINKWATCH_USER, LINKWATCH_PASSWORD)
     login_res = login_endpoint.post()
     if login_res.is_error():
-        logger.error("Could not log demo user in. " + login_res.get_error_reason())
+        logger.error("[linkwatch] Could not log demo user in. " + login_res.get_error_reason())
 
     token = login_res.get_token()
 
     if not token:
-        logger.error("Token unavailable due to error in login_endpoint call. Reason: " + login_res.get_error_reason())
+        logger.error("[linkwatch] Auth token unavailable due to error in login_endpoint call. Reason: " + login_res.get_error_reason())
     else:
-        logger.info("Token value is: " + token)
+        logger.info("[linkwatch] Auth token value is: " + token)
 
 
     # Send a weight measurement
@@ -209,19 +206,19 @@ def save_measurement(measurement_json):
         heartrate_measurement = Measurement(constants.MeasurementType.HF_HEARTRATE, measurement_json['value'], constants.UnitCode.BPM)
         obs = Observation(constants.DeviceType.HEART_RATE, t, "TEST", measurements=[heartrate_measurement], comment=measurement_json['input_source'])
     else:
-        logger.info("Unsupported measurement type: " + measurement_json['type'])
+        logger.info("[linkwatch] Unsupported measurement type: " + measurement_json['type'])
         return
 
     obs_endpoint = SendObservationsEndpoint(token, [obs])
     obs_res = obs_endpoint.post()
 
     if not obs_res.is_error():
-        logger.info("Observation status: " + str(obs_res.get_status()))
+        logger.info("[linkwatch] Observation status: " + str(obs_res.get_status()))
     else:
         try:
             obs_res.response.raise_for_status()
         except Exception, e:
-            logging.exception("Failed to send new weight observation!", e)
+            logging.exception("[linkwatch] Failed to send new weight observation!", e)
 
 
 if __name__ == "__main__":

--- a/linkwatch/settings.py
+++ b/linkwatch/settings.py
@@ -7,6 +7,9 @@ LINKWATCH_URL_BASE = "https://linkwatchrestservicetest.azurewebsites.net/"
 LINKWATCH_USER = 'CNetDemo'
 LINKWATCH_PASSWORD = 'password'
 
+PAPERTRAILS_LOGGING_HOSTNAME = 'logs4.papertrailapp.com'
+PAPERTRAILS_LOGGING_PORT = 43843
+
 try:
     from settings_local import *
 except:

--- a/linkwatch/tasks.py
+++ b/linkwatch/tasks.py
@@ -1,6 +1,8 @@
 from celery import Celery
 from kombu import Queue, Exchange
 from kombu.common import Broadcast
+from custom_logging import logger
+
 import endpoints
 from settings import *
 
@@ -14,4 +16,5 @@ app.conf.update(
 
 @app.task(name=BROKER_TASK)
 def parse_measurement(measurement_json):
+    logger.debug('[linkwatch] Parse measurement request: %s' % (measurement_json))
     endpoints.save_measurement(measurement_json)

--- a/medical_compliance/medical_compliance/api/analyzers/heart_rate_analyzers.py
+++ b/medical_compliance/medical_compliance/api/analyzers/heart_rate_analyzers.py
@@ -35,6 +35,9 @@ def analyze_heart_rates(last_measurement, input_source):
 # TODO: this is a dummy module and should be generalized at least with a task structure
 # all the tasks should listen on the same heart rate queue and all of them should compute some metrics (broadcast?)
 def analyze_last_heart_rates(last_measurement, input_source):
+    logger.debug("Analyze heart rates request: { last_measurement: %s, input_source: %s }" % 
+        (last_measurement, input_source))
+
     last_timestamp = 0
 
     if last_measurement:
@@ -43,6 +46,9 @@ def analyze_last_heart_rates(last_measurement, input_source):
     measurement_list = HeartRateMeasurement.objects.filter(
         timestamp__gt=last_timestamp
     ).filter(input_source=input_source).order_by('timestamp')
+
+    logger.debug("Measurements since last measurement (%s): %s" % 
+        (last_measurement, measurement_list))
 
     notifications_adapter = NotificationsAdapter()
 

--- a/medical_compliance/medical_compliance/api/analyzers/heart_rate_analyzers.py
+++ b/medical_compliance/medical_compliance/api/analyzers/heart_rate_analyzers.py
@@ -35,7 +35,7 @@ def analyze_heart_rates(last_measurement, input_source):
 # TODO: this is a dummy module and should be generalized at least with a task structure
 # all the tasks should listen on the same heart rate queue and all of them should compute some metrics (broadcast?)
 def analyze_last_heart_rates(last_measurement, input_source):
-    logger.debug("Analyze heart rates request: { last_measurement: %s, input_source: %s }" % 
+    logger.debug("[medical-compliance] Analyze heart rates request: { last_measurement: %s, input_source: %s }" % 
         (last_measurement, input_source))
 
     last_timestamp = 0
@@ -47,7 +47,7 @@ def analyze_last_heart_rates(last_measurement, input_source):
         timestamp__gt=last_timestamp
     ).filter(input_source=input_source).order_by('timestamp')
 
-    logger.debug("Measurements since last measurement (%s): %s" % 
+    logger.debug("[medical-compliance] Measurements since last measurement (%s): %s" % 
         (last_measurement, measurement_list))
 
     notifications_adapter = NotificationsAdapter()

--- a/medical_compliance/medical_compliance/api/analyzers/weight_analyzers.py
+++ b/medical_compliance/medical_compliance/api/analyzers/weight_analyzers.py
@@ -33,11 +33,15 @@ def analyze_weights(weight_measurement_id):
 # TODO: this is a dummy module and should be generalized at least with a task structure
 # all the tasks should listen on the same weight queue and all of them should compute some metrics (broadcast?)
 def analyze_last_two_weights(weight_measurement_id):
-    logger.debug("Analyze weights request: { weight_measurement_id: %s }" % (weight_measurement_id))
+    logger.debug("[medical-compliance] Analyze weights request: { weight_measurement_id: %s }" % 
+        (weight_measurement_id)
+    )
 
     measurement_list = WeightMeasurement.get_previous_weight_measures(weight_measurement_id, 2)
     
-    logger.debug("Last two weights for weight_measurement_id %s: %s" % (weight_measurement_id, measurement_list))
+    logger.debug("[medical-compliance] Last two weights for weight_measurement_id %s: %s" % 
+        (weight_measurement_id, measurement_list)
+    )
     
     if len(measurement_list) == 2:
         current_measurement= measurement_list[0]

--- a/medical_compliance/medical_compliance/api/analyzers/weight_analyzers.py
+++ b/medical_compliance/medical_compliance/api/analyzers/weight_analyzers.py
@@ -33,7 +33,12 @@ def analyze_weights(weight_measurement_id):
 # TODO: this is a dummy module and should be generalized at least with a task structure
 # all the tasks should listen on the same weight queue and all of them should compute some metrics (broadcast?)
 def analyze_last_two_weights(weight_measurement_id):
+    logger.debug("Analyze weights request: { weight_measurement_id: %s }" % (weight_measurement_id))
+
     measurement_list = WeightMeasurement.get_previous_weight_measures(weight_measurement_id, 2)
+    
+    logger.debug("Last two weights for weight_measurement_id %s: %s" % (weight_measurement_id, measurement_list))
+    
     if len(measurement_list) == 2:
         current_measurement= measurement_list[0]
         previous_measurement = measurement_list[1]

--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -20,6 +20,7 @@ from models import WeightMeasurement, HeartRateMeasurement
 from analyzers.weight_analyzers import analyze_weights
 from analyzers.heart_rate_analyzers import analyze_heart_rates
 
+logger = get_task_logger('medical_compliance_measurements.fetch_measurement')
 
 app = Celery('api.tasks', broker=settings.BROKER_URL)
 app.conf.update(
@@ -32,6 +33,9 @@ app.conf.update(
 
 @app.task(name='medical_compliance_measurements.fetch_weight_measurement')
 def fetch_weight_measurement(user_id, input_source, measurement_unit, timestamp, timezone, value):
+    logger.debug("Fetch weight measurement request: { user_id: %s, input_source: %s, measurement_unit: %s, timestamp: %s, timezone: %s, value: %s }" % 
+        (user_id, input_source, measurement_unit, timestamp, timezone, value))
+
     weight_measurement = WeightMeasurement(
         user_id = int(user_id),
         input_source=input_source,
@@ -50,6 +54,8 @@ def fetch_heart_rate_measurement():
         It's very ugly what I did here, only for demo purpose
         We MUST clean this
     """
+    logger.debug("Fetch heart measurement request")
+
     last_cinch_measurement = None
     last_test_measurement = None
 

--- a/medical_compliance/medical_compliance/api/withings_tasks.py
+++ b/medical_compliance/medical_compliance/api/withings_tasks.py
@@ -32,11 +32,8 @@ app.conf.update(
 @app.task(name='withings_controller.save_measurement')
 def save_measurement(userid, start_ts, end_ts, measurement_type_id):
     logger.debug(
-        "Sending request for measurement retrieval for userid: %s, start ts: %s, end ts: %s, type: %s",
-        str(userid),
-        str(start_ts),
-        str(end_ts),
-        str(measurement_type_id)
+        "Sending Withings request for measurement retrieval for { userid: %s, start ts: %s, end ts: %s, type: %s }" %
+        (userid, start_ts, end_ts, measurement_type_id)
     )
 
     credentials = WithingsCredentials(access_token=settings.WITHINGS_OAUTH_V1_TOKEN,
@@ -47,11 +44,18 @@ def save_measurement(userid, start_ts, end_ts, measurement_type_id):
     # TODO: modify storage of user credentials in settings file to a per userid basis
 
     client = WithingsApi(credentials)
-    response = client.request('measure', 'getmeas', {
-        'startdate': start_ts, 
+    req_params = {
+        'startdate': start_ts,
         'enddate': end_ts,
         'meastype': int(measurement_type_id)
-    })
+    }
+    response = client.request('measure', 'getmeas', req_params)
+
+    logger.debug(
+        "Got the following Withings response for user_id %s and req params %s: %s" %
+        (userid, req_params, response)
+    )
+
     measures = WithingsMeasures(response)
     timezoneStr = response['timezone']
     measurement_type = WithingsMeasurement.get_measure_type_by_id(int(measurement_type_id))

--- a/medical_compliance/medical_compliance/api/withings_tasks.py
+++ b/medical_compliance/medical_compliance/api/withings_tasks.py
@@ -32,7 +32,7 @@ app.conf.update(
 @app.task(name='withings_controller.save_measurement')
 def save_measurement(userid, start_ts, end_ts, measurement_type_id):
     logger.debug(
-        "Sending Withings request for measurement retrieval for { userid: %s, start ts: %s, end ts: %s, type: %s }" %
+        "[medical-compliance] Sending Withings request for measurement retrieval for { userid: %s, start ts: %s, end ts: %s, type: %s }" %
         (userid, start_ts, end_ts, measurement_type_id)
     )
 
@@ -52,7 +52,7 @@ def save_measurement(userid, start_ts, end_ts, measurement_type_id):
     response = client.request('measure', 'getmeas', req_params)
 
     logger.debug(
-        "Got the following Withings response for user_id %s and req params %s: %s" %
+        "[medical-compliance] Got the following Withings response for user_id %s and req params %s: %s" %
         (userid, req_params, response)
     )
 

--- a/medical_compliance/medical_compliance/settings.py
+++ b/medical_compliance/medical_compliance/settings.py
@@ -87,6 +87,8 @@ RAVEN_CONFIG = {
     'release': raven.fetch_git_sha(os.path.dirname(__file__) + "/../../")
 }
 
+PAPERTRAILS_LOGGING_HOSTNAME = 'logs4.papertrailapp.com'
+PAPERTRAILS_LOGGING_PORT = 43843
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,
@@ -110,16 +112,22 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
             'filename': './debug.log',
-        }
+        },
+        'syslog': {
+            'level':'DEBUG',
+            'class':'logging.handlers.SysLogHandler',
+            'formatter': 'verbose',
+            'address':(PAPERTRAILS_LOGGING_HOSTNAME, PAPERTRAILS_LOGGING_PORT)
+        },
     },
     'loggers': {
         'medical_compliance': {
             'level': 'DEBUG',
-            'handlers': ['sentry', 'console'],
+            'handlers': ['sentry', 'console', 'syslog'],
         },
         'api': {
             'level': 'DEBUG',
-            'handlers': ['sentry', 'console'],
+            'handlers': ['sentry', 'console', 'syslog'],
         },
         'django': {
             'level': 'DEBUG',

--- a/medical_compliance/medical_compliance/settings.py
+++ b/medical_compliance/medical_compliance/settings.py
@@ -153,20 +153,30 @@ LOGGING = {
             'handlers': ['sentry', 'console'],
         },
         'medical_compliance.measurement_callback': {
-            'handlers': ['file'],
+            'handlers': ['file', 'syslog'],
             'level': 'DEBUG',
             'propagate': True,
         },
         'withings_controller.save_measurement': {
-            'handlers': ['file'],
+            'handlers': ['file', 'syslog'],
             'level': 'DEBUG',
             'propagate': True,
         },
-        'medical_compliance.fetch_weight_measurement': {
-            'handlers': ['file'],
+        'medical_compliance_measurements.fetch_measurement': {
+            'handlers': ['file', 'syslog'],
             'level': 'DEBUG',
             'propagate': True,
         },
+        'medical_compliance_heart_rate_analyzers.analyze_heart_rates': {
+            'handlers': ['file', 'syslog'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'medical_compliance_weight_analyzers.analyze_weight': {
+            'handlers': ['file', 'syslog'],
+            'level': 'DEBUG',
+            'propagate': True,
+        }
     },
 }
 


### PR DESCRIPTION
## Why

Logging is one of the most important key aspects in software engineering. You usually want to log business errors or even exceptions that could happen in various scenarios with various degrees of importance (error, info, debug etc.). It's very important to have all of them centralized as it can help track future bugs / errors.
Also, it is very hard currently to track asynchronous tasks ran through Celery (difficult to find out the flow and debug errors).

## What

- [x] Integrate [Papertrail](https://docs.djangoproject.com/en/1.10/topics/logging/) 
- [x] Test and document the logging API (how you log with different levels, how you can attach stacks)
- [x] Log from all the asynchronous celery tasks (include input parameters)

## Notes

Some research for other frameworks would be welcome
The logging should be done with a tag/a description at the beginning stating clearly the name of the Microservice (e.g. medical-compliance or linkwatch)