### PR TITLE
Project Refactoring & Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This command should be left in a cmd and to add tasks asynchronously we'll need 
 ```
 $ python manage.py shell
 > import medical_compliance
-> medical_compliance.celery.app.send_task('withings_controller.save_measurement', [11262861, 1273406557553, 1473406557553, 1])
+> medical_compliance.celery.app.send_task('withings_controller.retrieve_and_save_withings_measurements', [11262861, 1273406557553, 1473406557553, 1])
 ```
 The last command will generate some output in the celery task console (currently it has an error).
 

--- a/frontend/api/tasks.py
+++ b/frontend/api/tasks.py
@@ -30,14 +30,16 @@ app.conf.update(
 
 @celery.task(name='frontend.send_notification')
 def send_notification(user_id, recipient_type, type, severity, message, description, timestamp):
-    logger.debug("[frontend] Send notification request: { user_id: %s, recipient_type: %s, type: %s, severity: %s, message: %s, description: %s, timestamp: %s}" 
-        % (user_id, recipient_type, type, severity, message, description, timestamp))
+    logger.debug("[frontend] Send notification request: %s" % (locals()))
 
     if timestamp is None:
         timestamp = time.time()
+        
     n = Notification(user_id=user_id, recipient_type=recipient_type, type=type, severity=severity, timestamp=timestamp, message=message, description=description)
     n.full_clean()
     n.save()
 
     devices = APNSDevice.objects.filter(name=recipient_type)
     devices.send_message(message, sound="default")
+    
+    logger.debug("[frontend] Notifications were successfully sent.")

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -5,7 +5,7 @@ import datetime, pytz
 import constants
 
 from custom_logging import logger
-from settings import *
+from settings import LINKWATCH_URL_BASE, LINKWATCH_USER, LINKWATCH_PASSWORD
 
 class EndpointResult(object):
     '''

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -192,9 +192,10 @@ def process_measurement(measurement_json):
         logger.error("[linkwatch] Auth token unavailable due to error in login_endpoint call. Reason: %s" % (login_res.get_error_reason()))
     else:
         logger.info("[linkwatch] Auth token value is: %s" % (token))
-
+    
+    obs = None
     try:
-        obs_res.response.raise_for_status()
+        obs = get_observation_from_measurement_json(measurement_json)
     except Exception, e:
         logger.error("[linkwatch] Could not convert measurement to linkwatch observation: %s" % (measurement_json))
         return
@@ -202,7 +203,7 @@ def process_measurement(measurement_json):
     send_observation(token, obs)
 
 def get_api_token():
-    logger.error("[linkwatch] Getting auth token...")
+    logger.debug("[linkwatch] Getting auth token...")
 
     login_endpoint = LoginEndpoint(LINKWATCH_USER, LINKWATCH_PASSWORD)
     login_res = login_endpoint.post()
@@ -212,7 +213,7 @@ def get_api_token():
     return login_res.get_token()
 
 def get_observation_from_measurement_json(measurement_json):
-    logger.error("[linkwatch] Converting measurement %s to linkwatch observation..." % (measurement_json))
+    logger.debug("[linkwatch] Converting measurement %s to linkwatch observation..." % (measurement_json))
 
     t = datetime.datetime.fromtimestamp(measurement_json['timestamp'])
     if measurement_json['type'] == 'weight':

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -169,7 +169,10 @@ class Measurement(object):
                     "TypeId": None,
                     "Context": None
                 }
-
+    
+    def __str__(self):
+        return "{ type: %s, value: %s, measurement_unit: %s, context_type: %s }" % \
+            (self.type, self.value, self.measurement_unit, self.context_type)
 
 
 class Observation(object):

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -189,14 +189,14 @@ def process_measurement(measurement_json):
     token = get_api_token()
 
     if not token:
-        logger.error("[linkwatch] Auth token unavailable due to error in login_endpoint call. Reason: " + login_res.get_error_reason())
+        logger.error("[linkwatch] Auth token unavailable due to error in login_endpoint call. Reason: %s" % (login_res.get_error_reason()))
     else:
-        logger.info("[linkwatch] Auth token value is: " + token)
+        logger.info("[linkwatch] Auth token value is: %s" % (token))
 
     try:
         obs_res.response.raise_for_status()
     except Exception, e:
-        logging.exception("[linkwatch] Could not convert measurement to linkwatch observation", e)
+        logger.error("[linkwatch] Could not convert measurement to linkwatch observation: %s" % (measurement_json))
         return
 
     send_observation(token, obs)
@@ -207,7 +207,7 @@ def get_api_token():
     login_endpoint = LoginEndpoint(LINKWATCH_USER, LINKWATCH_PASSWORD)
     login_res = login_endpoint.post()
     if login_res.is_error():
-        logger.error("[linkwatch] Could not log demo user in. " + login_res.get_error_reason())
+        logger.error("[linkwatch] Could not log demo user in. Login result: %s" % (login_res.get_error_reason()))
     
     return login_res.get_token()
 
@@ -234,7 +234,7 @@ def send_observation(api_token, observation):
         try:
             obs_res.response.raise_for_status()
         except Exception, e:
-            logging.exception("[linkwatch] Failed to POST new weight observation!", e)
+            logger.error("[linkwatch] Failed to POST new weight observation: %s" % (observation))
 
 if __name__ == "__main__":
     process_measurement({

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -181,48 +181,63 @@ class Observation(object):
         self.measurements = measurements
         self.comment = comment
 
+    def __str__(self):
+        return "{ device_type: %s, timestamp: %s, input_type: %s, equipment_id: %s, measurements: %s, comment: %s}" % \
+            (self.device_type, self.timestamp, self.input_type, self.equipment_id, self.measurements, self.comment)
 
-def save_measurement(measurement_json):
-    # Login and get API token
-    login_endpoint = LoginEndpoint(LINKWATCH_USER, LINKWATCH_PASSWORD)
-    login_res = login_endpoint.post()
-    if login_res.is_error():
-        logger.error("[linkwatch] Could not log demo user in. " + login_res.get_error_reason())
-
-    token = login_res.get_token()
+def process_measurement(measurement_json):
+    token = get_api_token()
 
     if not token:
         logger.error("[linkwatch] Auth token unavailable due to error in login_endpoint call. Reason: " + login_res.get_error_reason())
     else:
         logger.info("[linkwatch] Auth token value is: " + token)
 
+    try:
+        obs_res.response.raise_for_status()
+    except Exception, e:
+        logging.exception("[linkwatch] Could not convert measurement to linkwatch observation", e)
+        return
 
-    # Send a weight measurement
+    send_observation(token, obs)
+
+def get_api_token():
+    logger.error("[linkwatch] Getting auth token...")
+
+    login_endpoint = LoginEndpoint(LINKWATCH_USER, LINKWATCH_PASSWORD)
+    login_res = login_endpoint.post()
+    if login_res.is_error():
+        logger.error("[linkwatch] Could not log demo user in. " + login_res.get_error_reason())
+    
+    return login_res.get_token()
+
+def get_observation_from_measurement_json(measurement_json):
+    logger.error("[linkwatch] Converting measurement %s to linkwatch observation..." % (measurement_json))
+
     t = datetime.datetime.fromtimestamp(measurement_json['timestamp'])
     if measurement_json['type'] == 'weight':
         weight_measurement = Measurement(constants.MeasurementType.WEIGHT, measurement_json['value'], constants.UnitCode.KILOGRAM)
-        obs = Observation(constants.DeviceType.WEIGHTING_SCALE, t, "TEST", measurements=[weight_measurement], comment=measurement_json['input_source'])
+        return Observation(constants.DeviceType.WEIGHTING_SCALE, t, "TEST", measurements=[weight_measurement], comment=measurement_json['input_source'])
     elif measurement_json['type'] == 'heartrate':
         heartrate_measurement = Measurement(constants.MeasurementType.HF_HEARTRATE, measurement_json['value'], constants.UnitCode.BPM)
-        obs = Observation(constants.DeviceType.HEART_RATE, t, "TEST", measurements=[heartrate_measurement], comment=measurement_json['input_source'])
-    else:
-        logger.info("[linkwatch] Unsupported measurement type: " + measurement_json['type'])
-        return
+        return Observation(constants.DeviceType.HEART_RATE, t, "TEST", measurements=[heartrate_measurement], comment=measurement_json['input_source'])
 
-    obs_endpoint = SendObservationsEndpoint(token, [obs])
+    raise Exception("Unsupported measurement type: %s" % (measurement_json['type']))
+
+def send_observation(api_token, observation):
+    obs_endpoint = SendObservationsEndpoint(api_token, [observation])
     obs_res = obs_endpoint.post()
 
     if not obs_res.is_error():
-        logger.info("[linkwatch] Observation status: " + str(obs_res.get_status()))
+        logger.info("[linkwatch] Observation POST result for %s: %s" % (observation, obs_res.get_status()))
     else:
         try:
             obs_res.response.raise_for_status()
         except Exception, e:
-            logging.exception("[linkwatch] Failed to send new weight observation!", e)
-
+            logging.exception("[linkwatch] Failed to POST new weight observation!", e)
 
 if __name__ == "__main__":
-    save_measurement({
+    process_measurement({
         'type': 'weight',
         'user_id': 1234,
         'input_source': 'withings',

--- a/linkwatch/settings.py
+++ b/linkwatch/settings.py
@@ -1,7 +1,7 @@
 # Celery settings
 BROKER_URL = 'amqp://cami:cami@cami-rabbitmq:5672/cami'
 BROKER_QUEUE = 'broadcast_measurement'
-BROKER_TASK = 'cami.parse_measurement'
+BROKER_TASK = 'cami.on_measurement_received'
 
 LINKWATCH_URL_BASE = "https://linkwatchrestservicetest.azurewebsites.net/"
 LINKWATCH_USER = 'CNetDemo'

--- a/linkwatch/tasks.py
+++ b/linkwatch/tasks.py
@@ -19,6 +19,6 @@ app.conf.update(
 )
 
 @app.task(name=BROKER_TASK)
-def parse_measurement(measurement_json):
+def on_measurement_received(measurement_json):
     logger.debug('[linkwatch] Parse measurement request: %s' % (measurement_json))
     endpoints.save_measurement(measurement_json)

--- a/linkwatch/tasks.py
+++ b/linkwatch/tasks.py
@@ -20,5 +20,5 @@ app.conf.update(
 
 @app.task(name=BROKER_TASK)
 def on_measurement_received(measurement_json):
-    logger.debug('[linkwatch] Parse measurement request: %s' % (measurement_json))
-    endpoints.save_measurement(measurement_json)
+    logger.debug('[linkwatch] Measurement received: %s' % (measurement_json))
+    endpoints.process_measurement(measurement_json)

--- a/medical_compliance/medical_compliance/api/analyzers/heart_rate_analyzers.py
+++ b/medical_compliance/medical_compliance/api/analyzers/heart_rate_analyzers.py
@@ -35,8 +35,7 @@ def analyze_heart_rates(last_measurement, input_source):
 # TODO: this is a dummy module and should be generalized at least with a task structure
 # all the tasks should listen on the same heart rate queue and all of them should compute some metrics (broadcast?)
 def analyze_last_heart_rates(last_measurement, input_source):
-    logger.debug("[medical-compliance] Analyze heart rates request: { last_measurement: %s, input_source: %s }" % 
-        (last_measurement, input_source))
+    logger.debug("[medical-compliance] Analyze heart rates request: %s" % (locals()))
 
     last_timestamp = 0
 
@@ -47,13 +46,15 @@ def analyze_last_heart_rates(last_measurement, input_source):
         timestamp__gt=last_timestamp
     ).filter(input_source=input_source).order_by('timestamp')
 
-    logger.debug("[medical-compliance] Measurements since last measurement (%s): %s" % 
+    logger.debug("[medical-compliance] Heart rate measurements since last measurement (%s): %s" % 
         (last_measurement, measurement_list))
 
     notifications_adapter = NotificationsAdapter()
 
     for m in measurement_list:
         if m.value < 60:
+            logger.debug("[medical-compliance] Heart rate measurement value < 60. Sending notifications to caregiver + elderly.")
+            
             message = u"Jim's heart rate is dangerously low: only %d." % int(m.value)
             description = "Please take action now!"
             notifications_adapter.send_caregiver_notification(measurement_list[0].user_id, "heart", "high", message, description, m.timestamp)
@@ -62,6 +63,8 @@ def analyze_last_heart_rates(last_measurement, input_source):
             description = "I have contacted your caregiver."
             notifications_adapter.send_elderly_notification(measurement_list[0].user_id, "heart", "high", message, description, m.timestamp)
         elif m.value < 70:
+            logger.debug("[medical-compliance] Heart rate measurement value < 70. Sending notifications to caregiver + elderly.")
+
             message = u"Jim's heart rate is a bit low: only %d" % int(m.value)
             description = "Please make sure he's all right."
             notifications_adapter.send_caregiver_notification(measurement_list[0].user_id, "heart", "medium", message, description, m.timestamp)
@@ -71,6 +74,8 @@ def analyze_last_heart_rates(last_measurement, input_source):
             notifications_adapter.send_elderly_notification(measurement_list[0].user_id, "heart", "medium", message, description, m.timestamp)
 
         if m.value > 100:
+            logger.debug("[medical-compliance] Heart rate measurement value > 100. Sending notifications to caregiver + elderly.")
+
             message = u"Jim's heart rate is dangerously high: over %d." % int(m.value)
             description = "Please take action now!"
             notifications_adapter.send_caregiver_notification(measurement_list[0].user_id, "heart", "high", message, description, m.timestamp)
@@ -80,6 +85,8 @@ def analyze_last_heart_rates(last_measurement, input_source):
             notifications_adapter.send_elderly_notification(measurement_list[0].user_id, "heart", "high", message, description, m.timestamp)
 
         elif m.value > 85:
+            logger.debug("[medical-compliance] Heart rate measurement value < 85. Sending notifications to caregiver + elderly.")
+
             message = u"Jim's heart rate is a bit high: over %d." % int(m.value)
             description = "Please make sure he's alright."
             notifications_adapter.send_caregiver_notification(measurement_list[0].user_id, "heart", "medium", message, description, m.timestamp)

--- a/medical_compliance/medical_compliance/api/analyzers/weight_analyzers.py
+++ b/medical_compliance/medical_compliance/api/analyzers/weight_analyzers.py
@@ -58,7 +58,7 @@ def analyze_last_two_weights(weight_measurement_id):
             description = "Please take your meals regularly."
             notifications_adapter.send_elderly_notification(current_measurement.user_id, "weight", "medium", message, description)
 
-        if delta_value >= DELTA_WEIGHT:
+        elif delta_value >= DELTA_WEIGHT:
             logger.debug("[medical-compliance] New weight measurement > last one. Difference: %s. Sending notifications..." % (delta_value))
 
             message = u"Jim gained %s kg" % (abs(delta_value))
@@ -68,3 +68,6 @@ def analyze_last_two_weights(weight_measurement_id):
             message = u"There's an increase of %s kg in your weight." % (abs(delta_value))
             description = "Please be careful with your meals."
             notifications_adapter.send_elderly_notification(current_measurement.user_id, "weight", "medium", message, description)
+        
+        else:
+            logger.debug("[medical-compliance] Weight difference < delta_weight (%s kg). Not sending notifications." % (delta_value))

--- a/medical_compliance/medical_compliance/api/analyzers/weight_analyzers.py
+++ b/medical_compliance/medical_compliance/api/analyzers/weight_analyzers.py
@@ -15,8 +15,9 @@ from notifications_adapter import NotificationsAdapter
 
 from ..models import WeightMeasurement
 
-logger = get_task_logger("medical_compliance_weight_analyzers.analyze_weight")
+DELTA_WEIGHT = 2
 
+logger = get_task_logger("medical_compliance_weight_analyzers.analyze_weight")
 
 app = Celery('api.tasks', broker=settings.BROKER_URL)
 app.conf.update(
@@ -33,24 +34,22 @@ def analyze_weights(weight_measurement_id):
 # TODO: this is a dummy module and should be generalized at least with a task structure
 # all the tasks should listen on the same weight queue and all of them should compute some metrics (broadcast?)
 def analyze_last_two_weights(weight_measurement_id):
-    logger.debug("[medical-compliance] Analyze weights request: { weight_measurement_id: %s }" % 
-        (weight_measurement_id)
-    )
-
+    logger.debug("[medical-compliance] Analyze weights request: %s. Trying to retrieve the last two weights..." % (locals()))
     measurement_list = WeightMeasurement.get_previous_weight_measures(weight_measurement_id, 2)
-    
-    logger.debug("[medical-compliance] Last two weights for weight_measurement_id %s: %s" % 
-        (weight_measurement_id, measurement_list)
-    )
+    logger.debug("[medical-compliance] The last two weights: %s" % (measurement_list))
     
     if len(measurement_list) == 2:
         current_measurement= measurement_list[0]
         previous_measurement = measurement_list[1]
         
+        logger.debug("[medical-compliance] Checking if the difference between the last two weight measurements is > %s" % (DELTA_WEIGHT))
+
         delta_value = current_measurement.value - previous_measurement.value
         notifications_adapter = NotificationsAdapter()
 
-        if delta_value <= -2:
+        if delta_value <= -1 * DELTA_WEIGHT:
+            logger.debug("[medical-compliance] New weight measurement < last one. Difference: %s. Sending notifications..." % (delta_value))
+
             message = u"Jim lost %s kg" % (abs(delta_value))
             description = "You can contact him and see what's wrong."
             notifications_adapter.send_caregiver_notification(current_measurement.user_id, "weight", "medium", message, description)
@@ -59,7 +58,9 @@ def analyze_last_two_weights(weight_measurement_id):
             description = "Please take your meals regularly."
             notifications_adapter.send_elderly_notification(current_measurement.user_id, "weight", "medium", message, description)
 
-        if delta_value >= 2:
+        if delta_value >= DELTA_WEIGHT:
+            logger.debug("[medical-compliance] New weight measurement > last one. Difference: %s. Sending notifications..." % (delta_value))
+
             message = u"Jim gained %s kg" % (abs(delta_value))
             description = "Please check if this has to do with his diet."
             notifications_adapter.send_caregiver_notification(current_measurement.user_id, "weight", "medium", message, description)

--- a/medical_compliance/medical_compliance/api/models.py
+++ b/medical_compliance/medical_compliance/api/models.py
@@ -68,7 +68,9 @@ class WithingsMeasurement(models.Model):
         import datetime, pytz
 
         pretty_date = datetime.datetime.fromtimestamp(self.timestamp, tz = pytz.timezone(self.timezone)).strftime("%Y-%m-%d %H:%M:%S %z")
-        return u'Measurement of type: %s, value: %s %s, from: %s' % (self.type, self.value, self.MEASUREMENT_SI_UNIT[self.type], pretty_date)
+        measurement_type = WithingsMeasurement.get_measure_type_by_id(self.type)
+        
+        return u'Measurement of type: %s, value: %s %s, from: %s' % (self.type, self.value, self.MEASUREMENT_SI_UNIT[measurement_type], pretty_date)
 
 
 class WeightMeasurement(models.Model):

--- a/medical_compliance/medical_compliance/api/models.py
+++ b/medical_compliance/medical_compliance/api/models.py
@@ -34,7 +34,7 @@ class WithingsMeasurement(models.Model):
     @staticmethod
     def get_measure_type_by_id(meas_id):
         for m in WithingsMeasurement.MEASURE_CHOICES:
-            if m[0] == meas_id:
+            if m[0] == int(meas_id):
                 return m[1]
 
         return None

--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -126,5 +126,5 @@ def broadcast_measurement(measurement_type, measurement):
         'value': measurement.value
     }
     
-    global_app.send_task('cami.parse_measurement', [measurement_json], queue='broadcast_measurement')
+    global_app.send_task('cami.on_measurement_received', [measurement_json], queue='broadcast_measurement')
     

--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -34,8 +34,8 @@ app.conf.update(
 )
 
 
-@app.task(name='medical_compliance_measurements.fetch_weight_measurement')
-def fetch_weight_measurement(user_id, input_source, measurement_unit, timestamp, timezone, value):
+@app.task(name='medical_compliance_measurements.process_weight_measurement')
+def process_weight_measurement(user_id, input_source, measurement_unit, timestamp, timezone, value):
     logger.debug("[medical-compliance] Fetch weight measurement request: %s" % (locals()))
 
     weight_measurement = WeightMeasurement(
@@ -56,8 +56,8 @@ def fetch_weight_measurement(user_id, input_source, measurement_unit, timestamp,
     logger.debug("[medical-compliance] Broadcasting weight measurement: %s" % (weight_measurement))
     broadcast_measurement('weight', weight_measurement)
 
-@app.task(name='medical_compliance_measurements.fetch_heart_rate_measurement')
-def fetch_heart_rate_measurement():
+@app.task(name='medical_compliance_measurements.process_heart_rate_measurement')
+def process_heart_rate_measurement():
     """
         It's very ugly what I did here, only for demo purpose
         We MUST clean this

--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -22,6 +22,9 @@ from analyzers.heart_rate_analyzers import analyze_heart_rates
 
 logger = get_task_logger('medical_compliance_measurements.fetch_measurement')
 
+global_app = Celery()
+global_app.config_from_object('django.conf:settings')
+
 app = Celery('api.tasks', broker=settings.BROKER_URL)
 app.conf.update(
     CELERY_DEFAULT_QUEUE='medical_compliance_measurements',
@@ -110,7 +113,6 @@ def broadcast_measurement(measurement_type, measurement):
         'timezone': measurement.timezone,
         'value': measurement.value
     }
-    global_app = Celery()
-    global_app.config_from_object('django.conf:settings')
+    
     global_app.send_task('cami.parse_measurement', [measurement_json], queue='broadcast_measurement')
     

--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -20,7 +20,7 @@ from models import WeightMeasurement, HeartRateMeasurement
 from analyzers.weight_analyzers import analyze_weights
 from analyzers.heart_rate_analyzers import analyze_heart_rates
 
-logger = get_task_logger('medical_compliance_measurements.fetch_measurement')
+logger = get_task_logger('medical_compliance_measurements.process_measurement')
 
 global_app = Celery()
 global_app.config_from_object('django.conf:settings')
@@ -36,7 +36,7 @@ app.conf.update(
 
 @app.task(name='medical_compliance_measurements.process_weight_measurement')
 def process_weight_measurement(user_id, input_source, measurement_unit, timestamp, timezone, value):
-    logger.debug("[medical-compliance] Fetch weight measurement request: %s" % (locals()))
+    logger.debug("[medical-compliance] Process weight measurement: %s" % (locals()))
 
     weight_measurement = WeightMeasurement(
         user_id = int(user_id),
@@ -62,7 +62,7 @@ def process_heart_rate_measurement():
         It's very ugly what I did here, only for demo purpose
         We MUST clean this
     """
-    logger.debug("[medical-compliance] Fetch heart measurement request: %s. Retrieving test and cinch heart rate measurements since the last one..." % (locals()))
+    logger.debug("[medical-compliance] Process heart measurement: %s. Retrieving test and cinch heart rate measurements since the last one..." % (locals()))
 
     last_cinch_measurement = None
     last_test_measurement = None

--- a/medical_compliance/medical_compliance/api/views.py
+++ b/medical_compliance/medical_compliance/api/views.py
@@ -8,7 +8,7 @@ from django.conf import settings #noqa
 from django.views.decorators.csrf import csrf_exempt
 
 from withings import WithingsApi, WithingsCredentials
-from withings_tasks import save_measurement
+from withings_tasks import retrieve_and_save_withings_measurements
 from tasks import process_heart_rate_measurement
 
 
@@ -57,9 +57,9 @@ def measurements_notification_received(request):
         enddate = request.POST['enddate']
         appli = request.POST['appli']
 
-        logger.debug("[medical-compliance] Passing data to the save_measurement task: { userid: %s, startdate: %s, enddate: %s, appli: %s }" %
+        logger.debug("[medical-compliance] Passing data to the retrieve_and_save_withings_measurements task: { userid: %s, startdate: %s, enddate: %s, appli: %s }" %
             (userid, startdate, enddate, appli))
-        save_measurement.delay(userid, startdate, enddate, appli)
+        retrieve_and_save_withings_measurements.delay(userid, startdate, enddate, appli)
     else:
         logger.debug("[medical-compliance] Received invalid POST data in measurements hook - possibly related to a subscribe call")
 

--- a/medical_compliance/medical_compliance/api/views.py
+++ b/medical_compliance/medical_compliance/api/views.py
@@ -9,7 +9,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from withings import WithingsApi, WithingsCredentials
 from withings_tasks import save_measurement
-from tasks import fetch_heart_rate_measurement
+from tasks import process_heart_rate_measurement
 
 
 logger = logging.getLogger("medical_compliance.measurement_callback")
@@ -45,7 +45,7 @@ def unsubscribe_notifications(request):
     return HttpResponse(json.dumps(response_data), content_type="application/json")
 
 def test_heart_rate_fetch(request):
-    return HttpResponse(fetch_heart_rate_measurement(), content_type="text/html")
+    return HttpResponse(process_heart_rate_measurement(), content_type="text/html")
 
 @csrf_exempt
 def measurements_notification_received(request):

--- a/medical_compliance/medical_compliance/api/views.py
+++ b/medical_compliance/medical_compliance/api/views.py
@@ -16,9 +16,10 @@ logger = logging.getLogger("medical_compliance.measurement_callback")
 
 
 def get_full_callback_url(request):
-    return request.build_absolute_uri("/notify_measurements/")
+    return request.build_absolute_uri("/measurements_notification/")
 
 def subscribe_notifications(request):
+    logger.debug("[medical-compliance] Notifications subscribe was called.")
     credentials = WithingsCredentials(access_token=settings.WITHINGS_OAUTH_V1_TOKEN,
                                       access_token_secret=settings.WITHINGS_OAUTH_V1_TOKEN_SECRET,
                                       consumer_key=settings.WITHINGS_CONSUMER_KEY,
@@ -26,32 +27,40 @@ def subscribe_notifications(request):
                                       user_id=settings.WITHINGS_USER_ID)
     client = WithingsApi(credentials)
     response_data = client.subscribe(get_full_callback_url(request), "Subscribe for weight measurement notifications.", appli=1)
+    logger.debug("[medical-compliance] Notifications subscribe response: %s." % (response_data))
+
     return HttpResponse(json.dumps(response_data), content_type="application/json")
 
 def unsubscribe_notifications(request):
+    logger.debug("[medical-compliance] Notifications unsubscribe was called.")
     credentials = WithingsCredentials(access_token=settings.WITHINGS_OAUTH_V1_TOKEN,
                                       access_token_secret=settings.WITHINGS_OAUTH_V1_TOKEN_SECRET,
                                       consumer_key=settings.WITHINGS_CONSUMER_KEY,
                                       consumer_secret=settings.WITHINGS_CONSUMER_SECRET,
                                       user_id=settings.WITHINGS_USER_ID)
     client = WithingsApi(credentials)
-    response_data = client.unsubscribe(get_full_callback_url(request), appli=1)
+    response_data = client.unsubscribe(get_full_callback_url(request), appli=1)    
+    logger.debug("[medical-compliance] Notifications unsubscribe response: %s." % (response_data))
+
     return HttpResponse(json.dumps(response_data), content_type="application/json")
 
 def test_heart_rate_fetch(request):
     return HttpResponse(fetch_heart_rate_measurement(), content_type="text/html")
 
 @csrf_exempt
-def notify_measurements(request):
-    logger.debug(pprint.pformat(request.POST))
+def measurements_notification_received(request):
+    logger.debug("[medical-compliance] Measurements hook was called: %s" % (request.POST))
     
     if request.POST.has_key("userid"):
         userid = request.POST['userid']
         startdate = request.POST['startdate']
         enddate = request.POST['enddate']
         appli = request.POST['appli']
+
+        logger.debug("[medical-compliance] Passing data to the save_measurement task: { userid: %s, startdate: %s, enddate: %s, appli: %s }" %
+            (userid, startdate, enddate, appli))
         save_measurement.delay(userid, startdate, enddate, appli)
     else:
-        logger.debug(pprint.pformat("Received invalid post data; possibly related to a subscribe call"))
+        logger.debug("[medical-compliance] Received invalid POST data in measurements hook - possibly related to a subscribe call")
 
     return HttpResponse(status=200)

--- a/medical_compliance/medical_compliance/api/withings_tasks.py
+++ b/medical_compliance/medical_compliance/api/withings_tasks.py
@@ -31,10 +31,7 @@ app.conf.update(
 
 @app.task(name='withings_controller.save_measurement')
 def save_measurement(userid, start_ts, end_ts, measurement_type_id):
-    logger.debug(
-        "[medical-compliance] Sending Withings request for measurement retrieval for { userid: %s, start ts: %s, end ts: %s, type: %s }" %
-        (userid, start_ts, end_ts, measurement_type_id)
-    )
+    logger.debug("[medical-compliance] Sending Withings request for measurement retrieval for %s" % (locals()))
 
     credentials = WithingsCredentials(access_token=settings.WITHINGS_OAUTH_V1_TOKEN,
                                       access_token_secret=settings.WITHINGS_OAUTH_V1_TOKEN_SECRET,

--- a/medical_compliance/medical_compliance/api/withings_tasks.py
+++ b/medical_compliance/medical_compliance/api/withings_tasks.py
@@ -15,7 +15,7 @@ from django.conf import settings #noqa
 from models import WithingsMeasurement
 from withings import WithingsCredentials, WithingsApi, WithingsMeasures
 
-from tasks import fetch_weight_measurement
+from tasks import process_weight_measurement
 
 logger = get_task_logger("withings_controller.save_measurement")
 
@@ -68,4 +68,4 @@ def save_measurement(userid, start_ts, end_ts, measurement_type_id):
             value=m.__getattribute__(measurement_type))
         meas.save()
 
-        fetch_weight_measurement.delay(userid, "withings", meas.measurement_unit, meas.timestamp, meas.timezone, meas.value)
+        process_weight_measurement.delay(userid, "withings", meas.measurement_unit, meas.timestamp, meas.timezone, meas.value)

--- a/medical_compliance/medical_compliance/api/withings_tasks.py
+++ b/medical_compliance/medical_compliance/api/withings_tasks.py
@@ -31,7 +31,7 @@ app.conf.update(
 
 @app.task(name='withings_controller.retrieve_and_save_withings_measurements')
 def retrieve_and_save_withings_measurements(userid, start_ts, end_ts, measurement_type_id):
-    logger.debug("[medical-compliance] Sending Withings request for measurement retrieval for %s" % (locals()))
+    logger.debug("[medical-compliance] Query Withings API to retrieve measurement: %s" % (locals()))
 
     credentials = WithingsCredentials(access_token=settings.WITHINGS_OAUTH_V1_TOKEN,
                                       access_token_secret=settings.WITHINGS_OAUTH_V1_TOKEN_SECRET,
@@ -66,6 +66,9 @@ def retrieve_and_save_withings_measurements(userid, start_ts, end_ts, measuremen
             timestamp=m.data['date'],
             timezone=timezoneStr,
             value=m.__getattribute__(measurement_type))
+
+        logger.debug("[medical-compliance] Saving Withings measurement in cami DB: %s" % (meas))
         meas.save()
 
+        logger.debug("[medical-compliance] Sending Withings weight measurement for processing: %s" % (meas))
         process_weight_measurement.delay(userid, "withings", meas.measurement_unit, meas.timestamp, meas.timezone, meas.value)

--- a/medical_compliance/medical_compliance/api/withings_tasks.py
+++ b/medical_compliance/medical_compliance/api/withings_tasks.py
@@ -17,7 +17,7 @@ from withings import WithingsCredentials, WithingsApi, WithingsMeasures
 
 from tasks import process_weight_measurement
 
-logger = get_task_logger("withings_controller.save_measurement")
+logger = get_task_logger("withings_controller.retrieve_and_save_withings_measurements")
 
 
 app = Celery('api.tasks', broker=settings.BROKER_URL)
@@ -29,8 +29,8 @@ app.conf.update(
 )
 
 
-@app.task(name='withings_controller.save_measurement')
-def save_measurement(userid, start_ts, end_ts, measurement_type_id):
+@app.task(name='withings_controller.retrieve_and_save_withings_measurements')
+def retrieve_and_save_withings_measurements(userid, start_ts, end_ts, measurement_type_id):
     logger.debug("[medical-compliance] Sending Withings request for measurement retrieval for %s" % (locals()))
 
     credentials = WithingsCredentials(access_token=settings.WITHINGS_OAUTH_V1_TOKEN,

--- a/medical_compliance/medical_compliance/settings.py
+++ b/medical_compliance/medical_compliance/settings.py
@@ -279,8 +279,8 @@ CELERY_QUEUES = (
     Queue('medical_compliance_heart_rate_analyzers', Exchange('medical_compliance_heart_rate_analyzers'), routing_key='medical_compliance_heart_rate_analyzers'),
     Broadcast('broadcast_measurement'),
 )
-# Every measurement sent on the broadcast_measurement queue will be broadcasted to all the workers that listen on the cami.parse_measurement task on it
-CELERY_ROUTES = {'cami.parse_measurement': {'queue': 'broadcast_measurement'}}
+# Every measurement sent on the broadcast_measurement queue will be broadcasted to all the workers that listen on the cami.on_measurement_received task on it
+CELERY_ROUTES = {'cami.on_measurement_received': {'queue': 'broadcast_measurement'}}
 
 try:
     from settings_local import *

--- a/medical_compliance/medical_compliance/settings.py
+++ b/medical_compliance/medical_compliance/settings.py
@@ -162,7 +162,7 @@ LOGGING = {
             'level': 'DEBUG',
             'propagate': True,
         },
-        'medical_compliance_measurements.fetch_measurement': {
+        'medical_compliance_measurements.process_measurement': {
             'handlers': ['file', 'syslog'],
             'level': 'DEBUG',
             'propagate': True,

--- a/medical_compliance/medical_compliance/settings.py
+++ b/medical_compliance/medical_compliance/settings.py
@@ -263,7 +263,7 @@ GOOGLE_FIT_REFRESH_TOKEN = '1/bcaHAkmLUs6Is5pTyVhqtjw0vYIqbZcWkuTnQWNf87c'
 # Google Fit Fetch Heart Rate Scheduled Task
 CELERYBEAT_SCHEDULE = {
     'fetch_heart_rate_data': {
-        'task': 'medical_compliance_measurements.fetch_heart_rate_measurement',
+        'task': 'medical_compliance_measurements.process_heart_rate_measurement',
         'schedule': timedelta(minutes=5),
     }
 }

--- a/medical_compliance/medical_compliance/settings.py
+++ b/medical_compliance/medical_compliance/settings.py
@@ -157,7 +157,7 @@ LOGGING = {
             'level': 'DEBUG',
             'propagate': True,
         },
-        'withings_controller.save_measurement': {
+        'withings_controller.retrieve_and_save_withings_measurements': {
             'handlers': ['file', 'syslog'],
             'level': 'DEBUG',
             'propagate': True,

--- a/medical_compliance/medical_compliance/urls.py
+++ b/medical_compliance/medical_compliance/urls.py
@@ -30,6 +30,6 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^subscribe_notifications/', views.subscribe_notifications, name="subscribe_notifications"),
     url(r'^unsubscribe_notifications/', views.unsubscribe_notifications, name="unsubscribe_notifications"),
-    url(r'^notify_measurements/$', views.notify_measurements, name="notify_measurements"),
+    url(r'^measurements_notification/$', views.measurements_notification_received, name="measurements_notification_received"),
     url(r'^test/$', views.test_heart_rate_fetch, name="test_heart_rate_fetch"),
 ]


### PR DESCRIPTION
## Why

The integration between CAMI and Linkwatch has been done in #121, but still has some problems which need to be taken care of.

## What

- [x] In the `linkwatch/endpoints.py` file, it is a bad practice to import the settings like `from settings import *` as it could pollute the local namespace
- [x] In `medical_compliance/api/tasks.py`, the next lines could create an overhead and should be initialized only once
```
global_app = Celery()
global_app.config_from_object('django.conf:settings')
```
- [x] Refactor the names of the queues within celery and the task names (they are not that intuitive) 

- [x] Rename Withings hook method - choose something intuitive

- [x] Review & clean logging

## Notes
