### PR TITLE
Logging cleanup

### DIFF
--- a/linkwatch/custom_logging.py
+++ b/linkwatch/custom_logging.py
@@ -1,14 +1,17 @@
+import sys
 import logging
-import settings
 
 from logging.handlers import SysLogHandler
+from celery.utils.log import get_task_logger
+from settings import PAPERTRAILS_LOGGING_HOSTNAME, PAPERTRAILS_LOGGING_PORT
 
-logger = logging.getLogger()
+logger = get_task_logger('linkwatch')
 logger.setLevel(logging.DEBUG)
 
-syslog = SysLogHandler(address=(settings.PAPERTRAILS_LOGGING_HOSTNAME, settings.PAPERTRAILS_LOGGING_PORT))
 formatter = logging.Formatter('%(levelname)s %(asctime)s %(module)s '
                       '%(process)d %(thread)d %(message)s')
 
+syslog = SysLogHandler(address=(PAPERTRAILS_LOGGING_HOSTNAME, PAPERTRAILS_LOGGING_PORT))
 syslog.setFormatter(formatter)
+
 logger.addHandler(syslog)

--- a/linkwatch/tasks.py
+++ b/linkwatch/tasks.py
@@ -1,10 +1,28 @@
 from celery import Celery
 from kombu import Queue, Exchange
 from kombu.common import Broadcast
-from custom_logging import logger
 
 import endpoints
 from settings import *
+
+import logging
+from logging.handlers import SysLogHandler
+import sys
+
+root = logging.getLogger()
+root.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+stdout = logging.StreamHandler(sys.stdout)
+stdout.setFormatter(formatter)
+
+syslog = SysLogHandler(address=(PAPERTRAILS_LOGGING_HOSTNAME, PAPERTRAILS_LOGGING_PORT))
+syslog.setFormatter(formatter)
+
+root.addHandler(stdout)
+root.addHandler(syslog)
+
 
 app = Celery('api.tasks', broker=BROKER_URL)
 app.conf.update(
@@ -16,5 +34,5 @@ app.conf.update(
 
 @app.task(name=BROKER_TASK)
 def parse_measurement(measurement_json):
-    logger.debug('[linkwatch] Parse measurement request: %s' % (measurement_json))
+    root.debug('[linkwatch] Parse measurement request: %s' % (measurement_json))
     # endpoints.save_measurement(measurement_json)

--- a/linkwatch/tasks.py
+++ b/linkwatch/tasks.py
@@ -17,4 +17,4 @@ app.conf.update(
 @app.task(name=BROKER_TASK)
 def parse_measurement(measurement_json):
     logger.debug('[linkwatch] Parse measurement request: %s' % (measurement_json))
-    endpoints.save_measurement(measurement_json)
+    # endpoints.save_measurement(measurement_json)

--- a/linkwatch/tasks.py
+++ b/linkwatch/tasks.py
@@ -5,26 +5,10 @@ from kombu import Queue, Exchange
 from kombu.common import Broadcast
 
 import endpoints
-from settings import *
-
-import logging
-from logging.handlers import SysLogHandler
 import sys
 
-logger = get_task_logger('linkwatch')
-logger.setLevel(logging.DEBUG)
-
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-stdout = logging.StreamHandler(sys.stdout)
-stdout.setFormatter(formatter)
-
-syslog = SysLogHandler(address=(PAPERTRAILS_LOGGING_HOSTNAME, PAPERTRAILS_LOGGING_PORT))
-syslog.setFormatter(formatter)
-
-logger.addHandler(stdout)
-logger.addHandler(syslog)
-
+from custom_logging import logger
+from settings import *
 
 app = Celery('api.tasks', broker=BROKER_URL)
 app.conf.update(
@@ -37,4 +21,4 @@ app.conf.update(
 @app.task(name=BROKER_TASK)
 def parse_measurement(measurement_json):
     logger.debug('[linkwatch] Parse measurement request: %s' % (measurement_json))
-    # endpoints.save_measurement(measurement_json)
+    endpoints.save_measurement(measurement_json)

--- a/linkwatch/tasks.py
+++ b/linkwatch/tasks.py
@@ -1,4 +1,6 @@
 from celery import Celery
+from celery.utils.log import get_task_logger
+
 from kombu import Queue, Exchange
 from kombu.common import Broadcast
 
@@ -9,8 +11,8 @@ import logging
 from logging.handlers import SysLogHandler
 import sys
 
-root = logging.getLogger()
-root.setLevel(logging.DEBUG)
+logger = get_task_logger('linkwatch')
+logger.setLevel(logging.DEBUG)
 
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
@@ -20,8 +22,8 @@ stdout.setFormatter(formatter)
 syslog = SysLogHandler(address=(PAPERTRAILS_LOGGING_HOSTNAME, PAPERTRAILS_LOGGING_PORT))
 syslog.setFormatter(formatter)
 
-root.addHandler(stdout)
-root.addHandler(syslog)
+logger.addHandler(stdout)
+logger.addHandler(syslog)
 
 
 app = Celery('api.tasks', broker=BROKER_URL)
@@ -34,5 +36,5 @@ app.conf.update(
 
 @app.task(name=BROKER_TASK)
 def parse_measurement(measurement_json):
-    root.debug('[linkwatch] Parse measurement request: %s' % (measurement_json))
+    logger.debug('[linkwatch] Parse measurement request: %s' % (measurement_json))
     # endpoints.save_measurement(measurement_json)

--- a/linkwatch/tasks.py
+++ b/linkwatch/tasks.py
@@ -8,7 +8,7 @@ import endpoints
 import sys
 
 from custom_logging import logger
-from settings import *
+from settings import BROKER_URL, BROKER_QUEUE, BROKER_TASK
 
 app = Celery('api.tasks', broker=BROKER_URL)
 app.conf.update(

--- a/medical_compliance/medical_compliance/api/models.py
+++ b/medical_compliance/medical_compliance/api/models.py
@@ -95,7 +95,10 @@ class WeightMeasurement(models.Model):
         except ObjectDoesNotExist:
             return []
 
-
+    def __str__(self):
+        return "{ user_id: %s, input_source: %s, measurement_unit: %s, timestamp: %s, timezone: %s, value: %s}" % \
+            (self.user_id, self.input_source, self.measurement_unit, self.timestamp, self.timezone, self.value)
+            
 class HeartRateMeasurement(models.Model):
     INPUT_SOURCES = (
         ('cinch', 'cinch'),

--- a/medical_compliance/medical_compliance/api/models.py
+++ b/medical_compliance/medical_compliance/api/models.py
@@ -120,3 +120,7 @@ class HeartRateMeasurement(models.Model):
             return last_hr_measurements
         except ObjectDoesNotExist:
             return []
+    
+    def __str__(self):
+        return "{ user_id: %s, input_source: %s, measurement_unit: %s, timestamp: %s, timezone: %s, value: %s}" % \
+            (self.user_id, self.input_source, self.measurement_unit, self.timestamp, self.timezone, self.value)

--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -110,6 +110,9 @@ def broadcast_measurement(measurement_type, measurement):
         'timezone': measurement.timezone,
         'value': measurement.value
     }
+    
+    logger.debug("[medical-compliance] Broadcasting measurement: %s" % measurement_json)
+
     global_app = Celery()
     global_app.config_from_object('django.conf:settings')
     global_app.send_task('cami.parse_measurement', [measurement_json], queue='broadcast_measurement')

--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -33,7 +33,7 @@ app.conf.update(
 
 @app.task(name='medical_compliance_measurements.fetch_weight_measurement')
 def fetch_weight_measurement(user_id, input_source, measurement_unit, timestamp, timezone, value):
-    logger.debug("Fetch weight measurement request: { user_id: %s, input_source: %s, measurement_unit: %s, timestamp: %s, timezone: %s, value: %s }" % 
+    logger.debug("[medical-compliance] Fetch weight measurement request: { user_id: %s, input_source: %s, measurement_unit: %s, timestamp: %s, timezone: %s, value: %s }" % 
         (user_id, input_source, measurement_unit, timestamp, timezone, value))
 
     weight_measurement = WeightMeasurement(
@@ -54,7 +54,7 @@ def fetch_heart_rate_measurement():
         It's very ugly what I did here, only for demo purpose
         We MUST clean this
     """
-    logger.debug("Fetch heart measurement request")
+    logger.debug("[medical-compliance] Fetch heart measurement request")
 
     last_cinch_measurement = None
     last_test_measurement = None


### PR DESCRIPTION
## Why
This is follow-up issue for #84. It is mandatory for the logs to be clear and offer all the necessary context in order to make the tracking of future bugs / errors easier.

## What
- [x] add '[medical-compliance]' prefix for all the logs generated by the fetch_weight_measurement and fetch_heart_rate_measurement tasks

- [x] investigate why on production the logs generated from linkwatch do not get redirected to papertrail and fix it

- [x] stringify HeartRateMeasurement objects when displaying them in the logs

## Notes
Unlike other modules which are Django applications, linkwatch is a plain Python module. It might help when investigating why logs are not redirected to Papertrail.