### PR TITLE
Ensure that Withings weight is correctly synchronised to Linkwatch & OpenTele

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -7,16 +7,33 @@ The CAMI project allows for all the stakeholders involved to contribute to the d
 ## 1. Linkwatch
 
 We're currently sharing the following information w/ Linkwatch via their API, as soon as we register the information inside CAMI Cloud:
-* weight measurements
-* heart rate measurements
-* steps count measurements
+* **weight measurements**
+* **heart rate measurements**
+* **steps count measurements**
 
 #### API Documentation
 * Look over the [API's endpoints list](https://linkwatchrestservicetest.azurewebsites.net/Help/)
-* Play around with the API using [Postman](https://www.getpostman.com/)
-  * Import [the compiled list](https://www.getpostman.com/collections/3610b13f2b4f37f0223e) of Postman API interactions for the Linkwatch API
+* Play around with the API using [Postman](https://www.getpostman.com/) by importing [the compiled list](https://www.getpostman.com/collections/3610b13f2b4f37f0223e) of Postman API interactions for the Linkwatch API
 
 #### Testing
 * Use the information provided inside the [TESTING](TESTING.md) document to populate the CAMI Cloud with new measurements
 * Vist [Linkwatch's website](http://www.mylinkwatch.se/) and login using the credentials from LastPass
 * If all went well, the updated measurements should be visible on the [My Measurements page](http://www.mylinkwatch.se/my-measurements/)
+
+
+## 2. OpenTele
+
+We're currently sharing the following information w/ OpenTele via their API, as soon as we register the information inside CAMI Cloud:
+* **weight measurements**
+* **heart rate measurements**
+
+#### API Documentation
+* Look over the [API's endpoints list](https://bitbucket.org/4s/opentele2-citizen-server/src/afa35a584cbe2efe5adbdcc3dcd152d294243a34/docs/patient-api/PatientApi.md?at=master&fileviewer=file-view-default)
+* Play around with the API using [Postman](https://www.getpostman.com/) by importing [the compiled list](https://www.getpostman.com/collections/c03e6655dcb424673961) of Postman API interactions for the Linkwatch API
+  * You will also need to import the [environment configuration file](https://drive.google.com/open?id=0B5R_gDLmaW5Udk8zQVVPVVhfTnc) in order to have it working
+
+#### Testing
+* Use the information provided inside the [TESTING](TESTING.md) document to populate the CAMI Cloud with new measurements
+* Vist [OpenTele's dashboard](https://opentele.aliviate.dk:4287/opentele-server/) and login using the credentials from LastPass
+* If all went well, the updated measurements should be visible on the [CAMI measurements page](https://opentele.aliviate.dk:4287/opentele-server/patient/questionnaires/13)
+  * Take in consideration that the interface isn't translated to English yet

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -1,0 +1,22 @@
+# CAMI Integrations
+
+The CAMI project allows for all the stakeholders involved to contribute to the development and extension of its features. This entails that the information that is collected under the CAMI cloud must also be shared with the other stakeholders' systems.
+
+> The purpose of this document is to have a centralized overview of the consortium's 3rd pary systems integrated with the CAMI Cloud.
+
+## 1. Linkwatch
+
+We're currently sharing the following information w/ Linkwatch via their API, as soon as we register the information inside CAMI Cloud:
+* weight measurements
+* heart rate measurements
+* steps count measurements
+
+#### API Documentation
+* Look over the [API's endpoints list](https://linkwatchrestservicetest.azurewebsites.net/Help/)
+* Play around with the API using [Postman](https://www.getpostman.com/)
+  * Import [the compiled list](https://www.getpostman.com/collections/3610b13f2b4f37f0223e) of Postman API interactions for the Linkwatch API
+
+#### Testing
+* Use the information provided inside the [TESTING](TESTING.md) document to populate the CAMI Cloud with new measurements
+* Vist [Linkwatch's website](http://www.mylinkwatch.se/) and login using the credentials from LastPass
+* If all went well, the updated measurements should be visible on the [My Measurements page](http://www.mylinkwatch.se/my-measurements/)

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,15 @@
+# Testing CAMI Cloud's Functionality
+
+> The purpose of this document is to centralize the information required for insuring that CAMI Cloud functions properly.
+
+## Testing weight measurements
+
+CAMI Cloud integrates with the [Withings](https://www.withings.com/eu/en/) API for gathering weight measurements. Here's what's needed to test if measurements are processed accordingly throughout the CAMI Cloud system:
+
+* Visit [Withings](https://www.withings.com/eu/en/) and login using the credentials stored in LastPass
+* From the [Withings Health Mate](https://healthmate.withings.com/) Dashboard, press the **Add a measurement button** and add an arbitraruy new weight from the resulting modal window
+* The newly entered value will now be fetched and processed by the CAMI Cloud and show up on the various systems connected to it, like:
+  * the Papertrail logging system - credentials to access it are stored inside LastPass
+  * the CAMI iOS application
+  * the Linkwatch website - find out more in the [Integrations document](INTEGRATIONS.md)
+  * the OpenTele website - find out more in the [Integrations document](INTEGRATIONS.md)

--- a/TESTING.md
+++ b/TESTING.md
@@ -12,4 +12,4 @@ CAMI Cloud integrates with the [Withings](https://www.withings.com/eu/en/) API f
   * the Papertrail logging system - credentials to access it are stored inside LastPass
   * the CAMI iOS application
   * the Linkwatch website - find out more in the [Integrations document](INTEGRATIONS.md)
-  * the OpenTele website - find out more in the [Integrations document](INTEGRATIONS.md)
+  * the OpenTele dashboard - find out more in the [Integrations document](INTEGRATIONS.md)


### PR DESCRIPTION
## Why
For the CAMI consortium, it is extremely important for the stakeholders to have the systems they have built integrated. To this end, we have 3 main systems so far:
* CAMI, developed by UPB
* Linkwatch
* OpenTele

For the March mid-project meeting, we have proposed to demonstrate a working integration between CAMI and the other two. CAMI will be sending all the measurements it receives to the other 2 systems.

## What
* [x] a procedure for testing the integration between Withings weight and Linkwatch is documented
* [x] a procedure for testing the integration between Withings weight and OpenTele is documented
* [x] a resolution is provided on whether the 2 integrations are currently working or not (as a comment on this issue)

In the case where at least one of the two integrations is not working:
* [ ] a follow-up Github issue is created for each integration that is not working, with the recommended solution

## Notes
