### PR TITLE
Broadcast steps measurements and forward them to the Linkwatch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,12 @@ When running in development mode, you might get to the point when the Docker ins
 3. Start from scratch
     * run `$ docker-compose up` to get building again
 
+### Access individual containers
+
+You may sometimes want to check to see if a specific container is running that last bit of code, check on it's network connectivity, or anything else for that matter. If that's the case, here's what you should do:
+
+1. Get the container's hash
+    * run `$ docker ps` and copy the corresponding container's hash
+2. SSH it
+    * run `$ docker exec -ti HASH bash`
+    * you can also login as root by running `$ docker exec -ti -u root HASH bash`

--- a/README.md
+++ b/README.md
@@ -194,3 +194,25 @@ e.g. If you would like to aggregate per day the measurements in the last 3 days:
         }
     }
 ```
+
+## Troubleshooting Docker
+
+### The "Clean Slate" approach
+
+When running in development mode, you might get to the point when the Docker instances stop working correctly. It may either happen from the fact that you've made breaking changes or maybe just because some of the containers didn't update and don't run the last edits that you've just made. Either way, here's one way of starting from scratch and insuring that you don't inherit broken containers when restarting Docker.
+
+1. Insure that the Docker containers aren't running anymore
+    * run `$ docker-compose stop`
+    * run `$ docker ps` - and insure there are no lingering containers running
+2. Get rid of the current Docker images
+    * run `$ docker images` - and take note of the hash codes of the listed containers
+    * run `$ docker rmi -f HASH` - to delete the respective container images
+        * you can delte multiple container images at a time: `$ docker rmi -f HASH1 HASH2`
+        * there's no need to delete the following:
+            * `williamyeh/ansible`
+            * `rabbitmq`
+            * `mysql`
+    * run `$ docker-compose rm`
+3. Start from scratch
+    * run `$ docker-compose up` to get building again
+

--- a/README.md
+++ b/README.md
@@ -163,11 +163,8 @@ units - the number of time units
 
 e.g. If you would like to aggregate per day the measurements in the last 3 days:
     curl -X GET "http://cami.vitaminsoftware.com:8000/api/v1/steps-measurements/last_values?units=3&resolution=days"
-<<<<<<< HEAD
-    
-=======
 
->>>>>>> bfcf4a33d2d925575dcadc25e8d8c7bf256c5bc9
+```json
     {
         "steps":{
             "amount":[
@@ -196,3 +193,4 @@ e.g. If you would like to aggregate per day the measurements in the last 3 days:
             "status":"ok"
         }
     }
+```

--- a/linkwatch/constants.py
+++ b/linkwatch/constants.py
@@ -69,6 +69,7 @@ class UnitCode(Enum):
     KILOGRAM = 263875
     CELCIUS = 268192
     MMHG = 266016           # mmHg
+    STEP = 268800
 
 
 class ContextType(Enum):

--- a/linkwatch/constants.py
+++ b/linkwatch/constants.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+# You can find the complete list of supported device types here:
+# - https://linkwatchrestservicetest.azurewebsites.net/Help/ResourceModel?modelName=DeviceType
 class DeviceType(Enum):
     NOT_FOUND = -1
     PULSE_OXIMETER = 528388
@@ -22,7 +24,8 @@ class DeviceType(Enum):
     RESPIRATORY_RATE = 528397
     CHOLESTEROL = 528526
 
-
+# You can find the complete list of supported measurements here:
+# - https://linkwatchrestservicetest.azurewebsites.net/Help/ResourceModel?modelName=MeasurementType
 class MeasurementType(Enum):
     NOT_FOUND = -1
 
@@ -61,7 +64,8 @@ class MeasurementType(Enum):
     CHOLESTEROL = 188737
     TEMPERATURE = 150364
 
-
+# You can find the complete list of unit codes here:
+# - https://linkwatchrestservicetest.azurewebsites.net/Help/ResourceModel?modelName=UnitCode
 class UnitCode(Enum):
     NOT_FOUND = -1
     DIMLESS = 262656
@@ -71,7 +75,8 @@ class UnitCode(Enum):
     MMHG = 266016           # mmHg
     STEP = 268800
 
-
+# You can find the complete list of context types here:
+# - https://linkwatchrestservicetest.azurewebsites.net/Help/ResourceModel?modelName=ContextType
 class ContextType(Enum):
     EXERCISE = 29152
     CARB = 29156

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -228,6 +228,9 @@ def get_observation_from_measurement_json(measurement_json):
     elif measurement_json['type'] == 'heartrate':
         heartrate_measurement = Measurement(constants.MeasurementType.PULSE_RATE_NON_INV, measurement_json['value'], constants.UnitCode.BPM)
         return Observation(constants.DeviceType.BLOODPRESSURE, t, "TEST", measurements=[heartrate_measurement], comment=measurement_json['input_source'])
+    elif measurement_json['type'] == 'steps':
+        steps_measurement = Measurement(constants.MeasurementType.HF_STEPS, measurement_json['value'], constants.UnitCode.STEP)
+        return Observation(constants.DeviceType.STEP_COUNTER, t, "TEST", measurements=[steps_measurement], comment=measurement_json['input_source'])
 
     raise Exception("Unsupported measurement type: %s" % (measurement_json['type']))
 

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -226,8 +226,8 @@ def get_observation_from_measurement_json(measurement_json):
         weight_measurement = Measurement(constants.MeasurementType.WEIGHT, measurement_json['value'], constants.UnitCode.KILOGRAM)
         return Observation(constants.DeviceType.WEIGHTING_SCALE, t, "TEST", measurements=[weight_measurement], comment=measurement_json['input_source'])
     elif measurement_json['type'] == 'heartrate':
-        heartrate_measurement = Measurement(constants.MeasurementType.HF_HEARTRATE, measurement_json['value'], constants.UnitCode.BPM)
-        return Observation(constants.DeviceType.HEART_RATE, t, "TEST", measurements=[heartrate_measurement], comment=measurement_json['input_source'])
+        heartrate_measurement = Measurement(constants.MeasurementType.PULSE_RATE_NON_INV, measurement_json['value'], constants.UnitCode.BPM)
+        return Observation(constants.DeviceType.BLOODPRESSURE, t, "TEST", measurements=[heartrate_measurement], comment=measurement_json['input_source'])
 
     raise Exception("Unsupported measurement type: %s" % (measurement_json['type']))
 

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -23,7 +23,6 @@ class EndpointResult(object):
 
         return False
 
-
     def get_error_reason(self):
         if self.is_error():
             return self.response.reason
@@ -172,7 +171,7 @@ class Measurement(object):
                     "TypeId": None,
                     "Context": None
                 }
-    
+
     def __str__(self):
         return "{ type: %s, value: %s, measurement_unit: %s, context_type: %s }" % \
             (self.type, self.value, self.measurement_unit, self.context_type)
@@ -198,7 +197,7 @@ def process_measurement(measurement_json):
         logger.error("[linkwatch] Auth token unavailable due to error in login_endpoint call. Reason: %s" % (login_res.get_error_reason()))
     else:
         logger.info("[linkwatch] Auth token value is: %s" % (token))
-    
+
     obs = None
     try:
         obs = get_observation_from_measurement_json(measurement_json)
@@ -215,13 +214,14 @@ def get_api_token():
     login_res = login_endpoint.post()
     if login_res.is_error():
         logger.error("[linkwatch] Could not log demo user in. Login result: %s" % (login_res.get_error_reason()))
-    
+
     return login_res.get_token()
 
 def get_observation_from_measurement_json(measurement_json):
     logger.debug("[linkwatch] Converting measurement %s to linkwatch observation..." % (measurement_json))
 
     t = datetime.datetime.fromtimestamp(measurement_json['timestamp'])
+
     if measurement_json['type'] == 'weight':
         weight_measurement = Measurement(constants.MeasurementType.WEIGHT, measurement_json['value'], constants.UnitCode.KILOGRAM)
         return Observation(constants.DeviceType.WEIGHTING_SCALE, t, "TEST", measurements=[weight_measurement], comment=measurement_json['input_source'])
@@ -233,6 +233,7 @@ def get_observation_from_measurement_json(measurement_json):
         return Observation(constants.DeviceType.STEP_COUNTER, t, "TEST", measurements=[steps_measurement], comment=measurement_json['input_source'])
 
     raise Exception("Unsupported measurement type: %s" % (measurement_json['type']))
+
 
 def send_observation(api_token, observation):
     obs_endpoint = SendObservationsEndpoint(api_token, [observation])

--- a/linkwatch/endpoints.py
+++ b/linkwatch/endpoints.py
@@ -33,6 +33,9 @@ class EndpointResult(object):
     def get_status(self):
         return self.response.status_code
 
+    def get_text(self):
+        return self.response.text
+
 
 class LoginResult(EndpointResult):
     def get_token(self):
@@ -200,7 +203,7 @@ def process_measurement(measurement_json):
     try:
         obs = get_observation_from_measurement_json(measurement_json)
     except Exception, e:
-        logger.error("[linkwatch] Could not convert measurement to linkwatch observation: %s" % (measurement_json))
+        logger.error("[linkwatch] Could not convert measurement -- %s -- to linkwatch observation: %s" % (measurement_json, e))
         return
 
     send_observation(token, obs)
@@ -233,12 +236,12 @@ def send_observation(api_token, observation):
     obs_res = obs_endpoint.post()
 
     if not obs_res.is_error():
-        logger.info("[linkwatch] Observation POST result for %s: %s" % (observation, obs_res.get_status()))
+        logger.info("[linkwatch] Observation POST result for %s: %s -- with HTTP STATUS: %s" % (observation, obs_res.get_text(), obs_res.get_status()))
     else:
         try:
             obs_res.response.raise_for_status()
         except Exception, e:
-            logger.error("[linkwatch] Failed to POST new weight observation: %s" % (observation))
+            logger.error("[linkwatch] Failed to POST new weight observation %s: %s" % (observation, e))
 
 if __name__ == "__main__":
     process_measurement({

--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -220,4 +220,4 @@ def broadcast_measurement(measurement_type, measurement):
         }
 
     global_app.send_task('cami.on_measurement_received', [measurement_json], queue='broadcast_measurement')
-    
+    logger.debug("[medical-compliance] Broadcast for the %s measurement has been sent successfully" % (measurement_type))


### PR DESCRIPTION
## Why
Following the investigation into the Linkwatch integration for steps measurements in #137, we have found that the workflow for broadcasting steps is not implemented at all.

## What
* [x] the steps measurements are broadcasted to the `cami.on_measurements_received` queue
* [x] the Linkwatch worker is correctly configured to handle and forward the steps measurements to the API, as follows:
   * [x] the measurement data is assembled according to the Linkwatch API's format
   * [x] the measurement data is sent to Linkwatch API
   * [x] the measurement data is logged appropriately throughout the flow

## Notes
