### PR TITLE
Fix database settings in the frontend container

### DIFF
--- a/ansible/config/frontend/settings_local.py.j2
+++ b/ansible/config/frontend/settings_local.py.j2
@@ -10,7 +10,7 @@ DATABASES = {
             'sql_mode': 'TRADITIONAL',
             'charset': 'utf8',
             'init_command': 'SET '
-                'storage_engine=INNODB,'
+                'default_storage_engine=INNODB,'
                 'character_set_connection=utf8'
         }
     }

--- a/frontend/frontend/settings.py
+++ b/frontend/frontend/settings.py
@@ -169,7 +169,7 @@ DATABASES = {
             'sql_mode': 'TRADITIONAL',
             'charset': 'utf8',
             'init_command': 'SET '
-                'storage_engine=INNODB,'
+                'default_storage_engine=INNODB,'
                 'character_set_connection=utf8'
         }
     }


### PR DESCRIPTION
## Why
The `frontend` containers fail to start because of a setting that became non-valid once we upgraded MySQL to version `5.7`.

## What
- [x] Change `storage_engine` to `default_storage_engine` wherever is needed

## Notes
The error is:
`django.db.utils.OperationalError: (1193, "Unknown system variable 'storage_engine'")`