### PR TITLE
Update STORE_PORT in store_utils to match the port used in docker compose

### DIFF
--- a/medical_compliance/medical_compliance/api/store_utils.py
+++ b/medical_compliance/medical_compliance/api/store_utils.py
@@ -2,7 +2,7 @@ import requests
 import logging
 
 STORE_HOST = "localhost"
-STORE_PORT = "8000"
+STORE_PORT = "8008"
 STORE_ENDPOINT_URI = "http://" + STORE_HOST + ":" + STORE_PORT
 
 logger = logging.getLogger("medical_compliance.store_utils")


### PR DESCRIPTION
## Why
Currently, the `STORE_PORT` from `medical_compliance/medical_compliance/api/store_utils.py` is set to `8000`, which is not the actual port of `cami-store` application.

## What
- [x] Update the port to `8008`, which is used in docker-compose file

## Notes
