### PR TITLE
Update STORE_PORT in store_utils to match the store management container name

### DIFF
--- a/medical_compliance/medical_compliance/api/store_utils.py
+++ b/medical_compliance/medical_compliance/api/store_utils.py
@@ -1,7 +1,7 @@
 import requests
 import logging
 
-STORE_HOST = "localhost"
+STORE_HOST = "cami-store-management"
 STORE_PORT = "8008"
 STORE_ENDPOINT_URI = "http://" + STORE_HOST + ":" + STORE_PORT
 


### PR DESCRIPTION
## Why
Currently, the `STORE_HOST` from `medical_compliance/medical_compliance/api/store_utils.py` is set to `localhost`, which will point to the wrong place.

## What
- [x] Update the `STORE_HOST` to `cami-store-management`, which is the store management container name in docker-compose file

## Notes
