### PR TITLE
Investigate failure to receive push notifications in the iOS app

### DIFF
--- a/application/ios/Cami.xcodeproj/xcshareddata/xcschemes/Cami.xcscheme
+++ b/application/ios/Cami.xcodeproj/xcshareddata/xcschemes/Cami.xcscheme
@@ -85,6 +85,13 @@
             ReferencedContainer = "container:Cami.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
## Why
For the move from the 3AT Apple developer account to Vitamin's in #133 we also had to replace the Apple Push Notifications certificates, something that we tackled in #134.

Although the certificates have been changed, the push notifications are not being received on the iOS devices used for testing and running the app.

## What
* [ ] the cause for the push notifications not being received in the iOS app is investigated and follow-up issues are created, so that the following scenario works as expected:
   1. Ensure that you have logged in the iOS application w/ the Caregiver test account
   2. Trigger a manual heart rate measurement in the CAMI system using the test script w/ a dangerous value above `100 bpm`
   3. A push notification is received on the iOS device in a matter of minutes

## Notes
