### PR TITLE
iOS app Logout functionality is no longer working

### DIFF
--- a/application/src/modules/navigation/NavigationState.js
+++ b/application/src/modules/navigation/NavigationState.js
@@ -32,12 +32,16 @@ export function navigationCompleted() {
   return {type: NAVIGATION_COMPLETED};
 }
 
-// TODO: find a better way to navigate to the page than hardcoding the indexes from the routes
+// TODO(@parsaschiv.ionut): find a better way to navigate to the page
+//  than hardcoding the indexes from the routes
+// - (@rtud): in the meantime, see that when making changes to the
+//  initialState, like when you add a new screen for example, the index
+//  numbers reflect the order set below
 const LoginPageIndex = 0;
 const CaregiverPageIndex = 1;
-const ElderlyPageIndex = 4;
-const OnboardingPageIndex = 5;
-const LogoutPageIndex = 6;
+const ElderlyPageIndex = 5;
+const OnboardingPageIndex = 6;
+const LogoutPageIndex = 7;
 
 export function isLogoutPageIndex(index) {
   return index == LogoutPageIndex;


### PR DESCRIPTION
## Why
For the purpose of the consortium demo in the coming week, we need to be able to switch between users on the iOS app.

Following the recent feature additions in #157, pressing the Logout button no longer works as expected leaving the application in a "limbo" state.

## What
* [x] the logout functionality is debugged so that the following scenario works correctly:
   1. Open the iOS app
   2. Login w/ the test credentials
   3. Skip the on-boarding tour
   4. Press the Logout button in the Footer nav bar
   5. Logout is successful and you are taken back to the Login screen

## Notes
While resolving this bug, it would also be useful to investigate whether the login credentials are hard-coded inside the application or it requires communication w/ the CAMI Cloud API.