### PR TITLE
Fix debug statement in medical compliance application

### DIFF
--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -140,7 +140,7 @@ def process_heart_rate_measurement():
             logger.error("[medical-compliance] Cannot find any user - device combination with access config for "
                          "google_fit_userid : %s and device_id : %s" % (str(google_fit_userid), str(heartrate_device['id'])))
         else:
-            logger.error("[medical-compliance] Found user - device combination %s, for pulse measurements" % (
+            logger.debug("[medical-compliance] Found user - device combination %s, for pulse measurements" % (
                          str(device_usage_data)))
 
         cami_user_id = device_usage_data['user_id']
@@ -258,7 +258,7 @@ def process_steps_measurement():
             logger.error("[medical-compliance] Cannot find any user - device combination with access config for "
                          "google_fit_userid : %s and device_id : %s" % (str(google_fit_userid), str(steps_device['id'])))
         else:
-            logger.error("[medical-compliance] Found user - device combination %s, for step measurements" % (
+            logger.debug("[medical-compliance] Found user - device combination %s, for step measurements" % (
                 str(device_usage_data)))
 
         cami_user_id = device_usage_data['user_id']
@@ -284,7 +284,7 @@ def process_steps_measurement():
                                                 "start_timestamp": m['start_timestamp'],
                                                 "end_timestamp": m['end_timestamp']
                                                 })
-            logger.debug("[medical-compliance] Inserted pulse measurement in CAMI Store: %s" % (str(steps_meas_res)))
+            logger.debug("[medical-compliance] Inserted steps measurement in CAMI Store: %s" % (str(steps_meas_res)))
 
         logger.debug("[medical-compliance] Saving steps measurement: %s" % (steps_measurement))
         steps_measurement.save()


### PR DESCRIPTION
## Why
There is a debug statement that is defined as being an `ERROR`, but actually being a `DEBUG` message. This can be confusing and can lead to false alarms.

## What
- [x] Change the type from `ERROR` to `DEBUG` for `Found user - device combination [...] for pulse measurements` debug statement

## Notes
`ERROR 2017-03-24 11:31:15,747 tasks 73 140405709743872 [medical-compliance] Found user - device combination {'access_info': {u'google_fit_client_id': u'701996606933-17j7km8f8ce8vohhdcnur453cbn44aau.apps.googleusercontent.com', u'google_fit_hr_datastream_id': u'raw:com.google.heart_rate.bpm:com.ryansteckler.perfectcinch:', u'google_fit_refresh_token': u'1/eAhtNXxq65LeyzTr4aju27wCPLDAipXdrEd8ovgO8CY', u'google_fit_client_secret': u'K-lZ7t49-Gvhtz2P-RTqBhAQ', u'google_fit_steps_test_datastream_name': u'CAMI Steps Test', u'google_fit_hr_test_datastream_name': u'CAMI Heart Rate Test', u'google_fit_userid': u'11262861'}, 'user_id': 2, 'device_id': 2}, for pulse measurements`
