### PR TITLE
Weight measurements aren't being sent to the iOS app

### DIFF
--- a/medical_compliance/medical_compliance/api/tasks.py
+++ b/medical_compliance/medical_compliance/api/tasks.py
@@ -51,14 +51,14 @@ def process_weight_measurement(cami_user_id, device_id,
                                                              {"value" : value}
                                                              )
 
-    # weight_measurement = WeightMeasurement(
-    #     user_id = int(user_id),
-    #     input_source=input_source,
-    #     measurement_unit=measurement_unit,
-    #     timestamp=timestamp,
-    #     timezone=timezone,
-    #     value=value
-    # )
+    weight_measurement = WeightMeasurement(
+        user_id = int(cami_user_id),
+        input_source='withings',
+        measurement_unit=measurement_unit,
+        timestamp=timestamp,
+        timezone=timezone,
+        value=value
+    )
 
     logger.debug("[medical-compliance] Saving weight measurement: %s" % (str(weight_meas_res)))
 


### PR DESCRIPTION
## Why
As a Caregiver using the CAMI iOS app I need to keep updated with the status of the Elder I'm taking care of. Staying appraised with the Elder's weight allows me to monitor if he's eating and exercising correctly or not, and enables me to take the appropriate measures before it starts getting serious.

Following the changes brought by #151, new weight measurements from CAMI Cloud aren't being sent over to the iOS app.

## What
* [x] the problem with the weight measurements not being sent over is investigated, so that the following scenario works as expected:
   1. A new weight measurement is created via the Withings web dashboard
   2. The weight measurement is displayed inside the iOS app

## Notes