### PR TITLE
Forwarded measurements aren't displaying on the Linkwatch dashboard

### DIFF
--- a/linkwatch/settings.py
+++ b/linkwatch/settings.py
@@ -4,7 +4,7 @@ BROKER_QUEUE = 'broadcast_measurement'
 BROKER_TASK = 'cami.on_measurement_received'
 
 LINKWATCH_URL_BASE = "https://linkwatchrestservicetest.azurewebsites.net/"
-LINKWATCH_USER = 'CNetDemo'
+LINKWATCH_USER = 'CamiDemo'
 LINKWATCH_PASSWORD = 'password'
 
 PAPERTRAILS_LOGGING_HOSTNAME = 'logs4.papertrailapp.com'


### PR DESCRIPTION
## Why
The CAMI consortium will have a demo on March 30th, where the progress made to the project will be showcased.

Part of this presentation will be to demonstrate CAMI Cloud properly sending Google Fit measurements to Linkwatch & OpenTele systems.

Following the investigation in #178, we have found that CAMI Cloud is sending the measurements successfully, but the [Linkwatch Dashboard](http://www.mylinkwatch.se/my-measurements/) isn't displaying them.

## What
* [ ] the issue is communicated to Linkwatch and a resolution to this issue is posted below as a comment

## Notes
