### PR TITLE
Populate iOS app's Activities Screen with more types of events 

### DIFF
--- a/application/api-examples/activities/google-calendar-feed.json
+++ b/application/api-examples/activities/google-calendar-feed.json
@@ -1,5 +1,55 @@
 {
   "events": [{
+    "id": "06iibf5vv06qvqk8bmn61cldr0_20170327T053000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MDZpaWJmNXZ2MDZxdnFrOGJtbjYxY2xkcjBfMjAxNzAzMjdUMDUzMDAwWiA4cHVhcjBzYzRlN2VmbnM1cjg0OXJuMGx1c0Bn",
+    "created": 1490638350,
+    "updated": 1490780880,
+    "summary": "Time to exercise: Pushups",
+    "description": "2 sets of 10 pushups",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1490592600,
+    "end": 1490594400,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "8puar0sc4e7efns5r849rn0lus@group.calendar.google.com",
+      "name": "Exercise",
+      "color": {
+        "id": "9",
+        "background": "#7bd148",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170329T060000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MXMxb2pjbTBpZTFjN2plcHZzbGtybTc0Mm9fMjAxNzAzMjlUMDYwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1490767200,
+    "end": 1490767800,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
+      "color": {
+        "id": "4",
+        "background": "#fa573c",
+        "foreground": "#000000"
+      }
+    }
+  }, {
     "id": "06iibf5vv06qvqk8bmn61cldr0_20170329T053000Z",
     "status": "confirmed",
     "htmlLink": "https://www.google.com/calendar/event?eid=MDZpaWJmNXZ2MDZxdnFrOGJtbjYxY2xkcjBfMjAxNzAzMjlUMDUzMDAwWiA4cHVhcjBzYzRlN2VmbnM1cjg0OXJuMGx1c0Bn",

--- a/application/api-examples/activities/google-calendar-feed.json
+++ b/application/api-examples/activities/google-calendar-feed.json
@@ -13,7 +13,16 @@
     "end": 1492804800,
     "sequence": 0,
     "reminders": {
-     "useDefault": true
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "name": "Appointments",
+      "color": {
+        "id": "16",
+        "background": "#4986e7",
+        "foreground": "#000000"
+      }
     }
   }, {
     "id": "6mjooth4ue5cd82o1sdntc79tk",
@@ -29,7 +38,16 @@
     "end": 1493043300,
     "sequence": 0,
     "reminders": {
-     "useDefault": true
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "name": "Appointments",
+      "color": {
+        "id": "16",
+        "background": "#4986e7",
+        "foreground": "#000000"
+      }
     }
   }, {
     "id": "dj0eob3t7ap2pcihl8jjshvl60",
@@ -45,7 +63,16 @@
     "end": 1493305200,
     "sequence": 0,
     "reminders": {
-     "useDefault": true
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "name": "Appointments",
+      "color": {
+        "id": "16",
+        "background": "#4986e7",
+        "foreground": "#000000"
+      }
     }
   }, {
     "id": "h6it6k5aeire1kbreu0e57dv14",
@@ -61,7 +88,16 @@
     "end": 1493839800,
     "sequence": 0,
     "reminders": {
-     "useDefault": true
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "name": "Appointments",
+      "color": {
+        "id": "16",
+        "background": "#4986e7",
+        "foreground": "#000000"
+      }
     }
   }, {
     "id": "do756cgtb5pitpmd8cb2mk0el4",
@@ -77,7 +113,16 @@
     "end": 1493897400,
     "sequence": 0,
     "reminders": {
-     "useDefault": true
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "name": "Appointments",
+      "color": {
+        "id": "16",
+        "background": "#4986e7",
+        "foreground": "#000000"
+      }
     }
   }, {
     "id": "27uieel2459rd4oeu4f6c8njds",
@@ -93,7 +138,16 @@
     "end": 1495011600,
     "sequence": 0,
     "reminders": {
-     "useDefault": true
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "name": "Appointments",
+      "color": {
+        "id": "16",
+        "background": "#4986e7",
+        "foreground": "#000000"
+      }
     }
   }]
 }

--- a/application/api-examples/activities/google-calendar-feed.json
+++ b/application/api-examples/activities/google-calendar-feed.json
@@ -1,16 +1,116 @@
 {
   "events": [{
+    "id": "06iibf5vv06qvqk8bmn61cldr0_20170329T053000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MDZpaWJmNXZ2MDZxdnFrOGJtbjYxY2xkcjBfMjAxNzAzMjlUMDUzMDAwWiA4cHVhcjBzYzRlN2VmbnM1cjg0OXJuMGx1c0Bn",
+    "created": 1490638350,
+    "updated": 1490780880,
+    "summary": "Time to exercise: Crunches",
+    "description": "3 sets of 10 crunches",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1490765400,
+    "end": 1490767200,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "8puar0sc4e7efns5r849rn0lus@group.calendar.google.com",
+      "name": "Exercise",
+      "color": {
+        "id": "9",
+        "background": "#7bd148",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170330T060000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MDZpaWJmNXZ2MDZxdnFrOGJtbjYxY2xkcjBfMjAxNzAzMjlUMDUzMDAwWiA4cHVhcjBzYzRlN2VmbnM1cjg0OXJuMGx1c0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1490853600,
+    "end": 1490854200,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
+      "color": {
+        "id": "4",
+        "background": "#fa573c",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "06iibf5vv06qvqk8bmn61cldr0_20170331T053000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MDZpaWJmNXZ2MDZxdnFrOGJtbjYxY2xkcjBfMjAxNzAzMzFUMDUzMDAwWiA4cHVhcjBzYzRlN2VmbnM1cjg0OXJuMGx1c0Bn",
+    "created": 1490638350,
+    "updated": 1490780880,
+    "summary": "Time to exercise: Pushups",
+    "description": "2 sets of 10 pushups",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1490938200,
+    "end": 1490940000,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "8puar0sc4e7efns5r849rn0lus@group.calendar.google.com",
+      "name": "Exercise",
+      "color": {
+        "id": "9",
+        "background": "#7bd148",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170331T060000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MXMxb2pjbTBpZTFjN2plcHZzbGtybTc0Mm9fMjAxNzAzMzFUMDYwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1490940000,
+    "end": 1490940600,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
+      "color": {
+        "id": "4",
+        "background": "#fa573c",
+        "foreground": "#000000"
+      }
+    }
+  }, {
     "id": "l0qjggsh5te486cqlo603ied20",
     "status": "confirmed",
     "htmlLink": "https://www.google.com/calendar/event?eid=bDBxamdnc2g1dGU0ODZjcWxvNjAzaWVkMjAgZzgyMnJsMTRvc2pjNzVtZjg4bG92Y2k2a2dAZw",
     "created": 1489494141,
-    "updated": 1489494556,
+    "updated": 1490780968,
     "summary": "Meet with Jonas",
     "description": "Don't forget to ask about the fishing trip.",
     "location": "Ridgeway Park",
     "creator": "proiect.cami@gmail.com",
-    "start": 1492801200,
-    "end": 1492804800,
+    "start": 1490986800,
+    "end": 1490990400,
     "sequence": 0,
     "reminders": {
       "useDefault": true
@@ -25,77 +125,27 @@
       }
     }
   }, {
-    "id": "6mjooth4ue5cd82o1sdntc79tk",
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170401T060000Z",
     "status": "confirmed",
-    "htmlLink": "https://www.google.com/calendar/event?eid=Nm1qb290aDR1ZTVjZDgybzFzZG50Yzc5dGsgZzgyMnJsMTRvc2pjNzVtZjg4bG92Y2k2a2dAZw",
-    "created": 1489494218,
-    "updated": 1489494218,
-    "summary": "Checkup with Dr. Forrester",
-    "description": "Get blood work done.",
-    "location": "Mills Heights Clinic",
-    "creator": "proiect.cami@gmail.com",
-    "start": 1493032500,
-    "end": 1493043300,
-    "sequence": 0,
-    "reminders": {
-      "useDefault": true
-    },
-    "calendar": {
-      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
-      "name": "Appointments",
-      "color": {
-        "id": "16",
-        "background": "#4986e7",
-        "foreground": "#000000"
-      }
-    }
-  }, {
-    "id": "dj0eob3t7ap2pcihl8jjshvl60",
-    "status": "confirmed",
-    "htmlLink": "https://www.google.com/calendar/event?eid=ZGowZW9iM3Q3YXAycGNpaGw4ampzaHZsNjAgZzgyMnJsMTRvc2pjNzVtZjg4bG92Y2k2a2dAZw",
-    "created": 1489494280,
-    "updated": 1489494280,
-    "summary": "Grandchildren visiting",
-    "description": "Take little Nancy for ice-cream.",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MXMxb2pjbTBpZTFjN2plcHZzbGtybTc0Mm9fMjAxNzA0MDFUMDYwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
     "location": "Home",
     "creator": "proiect.cami@gmail.com",
-    "start": 1493280000,
-    "end": 1493305200,
+    "start": 1491026400,
+    "end": 1491027000,
     "sequence": 0,
     "reminders": {
       "useDefault": true
     },
     "calendar": {
-      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
-      "name": "Appointments",
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
       "color": {
-        "id": "16",
-        "background": "#4986e7",
-        "foreground": "#000000"
-      }
-    }
-  }, {
-    "id": "h6it6k5aeire1kbreu0e57dv14",
-    "status": "confirmed",
-    "htmlLink": "https://www.google.com/calendar/event?eid=aDZpdDZrNWFlaXJlMWticmV1MGU1N2R2MTQgZzgyMnJsMTRvc2pjNzVtZjg4bG92Y2k2a2dAZw",
-    "created": 1489494385,
-    "updated": 1489494385,
-    "summary": "Chess night with Steven",
-    "description": "Don't worry, you've got this!",
-    "location": "Home",
-    "creator": "proiect.cami@gmail.com",
-    "start": 1493830800,
-    "end": 1493839800,
-    "sequence": 0,
-    "reminders": {
-      "useDefault": true
-    },
-    "calendar": {
-      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
-      "name": "Appointments",
-      "color": {
-        "id": "16",
-        "background": "#4986e7",
+        "id": "4",
+        "background": "#fa573c",
         "foreground": "#000000"
       }
     }
@@ -104,13 +154,13 @@
     "status": "confirmed",
     "htmlLink": "https://www.google.com/calendar/event?eid=ZG83NTZjZ3RiNXBpdHBtZDhjYjJtazBlbDQgZzgyMnJsMTRvc2pjNzVtZjg4bG92Y2k2a2dAZw",
     "created": 1489494449,
-    "updated": 1489494449,
+    "updated": 1490781163,
     "summary": "Visiting the Allens",
     "description": "Don't forget to buy flowers!",
     "location": "56 Flower Road",
     "creator": "proiect.cami@gmail.com",
-    "start": 1493881200,
-    "end": 1493897400,
+    "start": 1491030000,
+    "end": 1491046200,
     "sequence": 0,
     "reminders": {
       "useDefault": true
@@ -125,17 +175,317 @@
       }
     }
   }, {
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170402T060000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MXMxb2pjbTBpZTFjN2plcHZzbGtybTc0Mm9fMjAxNzA0MDJUMDYwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491112800,
+    "end": 1491113400,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
+      "color": {
+        "id": "4",
+        "background": "#fa573c",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "06iibf5vv06qvqk8bmn61cldr0_20170403T053000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MDZpaWJmNXZ2MDZxdnFrOGJtbjYxY2xkcjBfMjAxNzA0MDNUMDUzMDAwWiA4cHVhcjBzYzRlN2VmbnM1cjg0OXJuMGx1c0Bn",
+    "created": 1490638350,
+    "updated": 1490780880,
+    "summary": "Time to exercise: Crunches",
+    "description": "3 sets of 10 crunches",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491197400,
+    "end": 1491199200,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "8puar0sc4e7efns5r849rn0lus@group.calendar.google.com",
+      "name": "Exercise",
+      "color": {
+        "id": "9",
+        "background": "#7bd148",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170403T060000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MXMxb2pjbTBpZTFjN2plcHZzbGtybTc0Mm9fMjAxNzA0MDNUMDYwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491199200,
+    "end": 1491199800,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
+      "color": {
+        "id": "4",
+        "background": "#fa573c",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "6mjooth4ue5cd82o1sdntc79tk",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=Nm1qb290aDR1ZTVjZDgybzFzZG50Yzc5dGsgZzgyMnJsMTRvc2pjNzVtZjg4bG92Y2k2a2dAZw",
+    "created": 1489494218,
+    "updated": 1490781078,
+    "summary": "Checkup with Dr. Forrester",
+    "description": "Get blood work done.",
+    "location": "Mills Heights Clinic",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491218100,
+    "end": 1491228900,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "name": "Appointments",
+      "color": {
+        "id": "16",
+        "background": "#4986e7",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170404T060000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MXMxb2pjbTBpZTFjN2plcHZzbGtybTc0Mm9fMjAxNzA0MDRUMDYwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491285600,
+    "end": 1491286200,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
+      "color": {
+        "id": "4",
+        "background": "#fa573c",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "dj0eob3t7ap2pcihl8jjshvl60",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=ZGowZW9iM3Q3YXAycGNpaGw4ampzaHZsNjAgZzgyMnJsMTRvc2pjNzVtZjg4bG92Y2k2a2dAZw",
+    "created": 1489494280,
+    "updated": 1490781099,
+    "summary": "Grandchildren visiting",
+    "description": "Take little Nancy for ice-cream.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491292800,
+    "end": 1491318000,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "name": "Appointments",
+      "color": {
+        "id": "16",
+        "background": "#4986e7",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "06iibf5vv06qvqk8bmn61cldr0_20170405T053000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MDZpaWJmNXZ2MDZxdnFrOGJtbjYxY2xkcjBfMjAxNzA0MDVUMDUzMDAwWiA4cHVhcjBzYzRlN2VmbnM1cjg0OXJuMGx1c0Bn",
+    "created": 1490638350,
+    "updated": 1490780880,
+    "summary": "Time to exercise: Pushups",
+    "description": "2 sets of 10 pushups",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491370200,
+    "end": 1491372000,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "8puar0sc4e7efns5r849rn0lus@group.calendar.google.com",
+      "name": "Exercise",
+      "color": {
+        "id": "9",
+        "background": "#7bd148",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170405T060000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MXMxb2pjbTBpZTFjN2plcHZzbGtybTc0Mm9fMjAxNzA0MDVUMDYwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491372000,
+    "end": 1491372600,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
+      "color": {
+        "id": "4",
+        "background": "#fa573c",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "h6it6k5aeire1kbreu0e57dv14",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=aDZpdDZrNWFlaXJlMWticmV1MGU1N2R2MTQgZzgyMnJsMTRvc2pjNzVtZjg4bG92Y2k2a2dAZw",
+    "created": 1489494385,
+    "updated": 1490781127,
+    "summary": "Chess night with Steven",
+    "description": "Don't worry, you've got this!",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491411600,
+    "end": 1491420600,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "name": "Appointments",
+      "color": {
+        "id": "16",
+        "background": "#4986e7",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170406T060000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MXMxb2pjbTBpZTFjN2plcHZzbGtybTc0Mm9fMjAxNzA0MDZUMDYwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491458400,
+    "end": 1491459000,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
+      "color": {
+        "id": "4",
+        "background": "#fa573c",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "06iibf5vv06qvqk8bmn61cldr0_20170407T053000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MDZpaWJmNXZ2MDZxdnFrOGJtbjYxY2xkcjBfMjAxNzA0MDdUMDUzMDAwWiA4cHVhcjBzYzRlN2VmbnM1cjg0OXJuMGx1c0Bn",
+    "created": 1490638350,
+    "updated": 1490780880,
+    "summary": "Time to exercise: Crunches",
+    "description": "3 sets of 10 crunches",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491543000,
+    "end": 1491544800,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "8puar0sc4e7efns5r849rn0lus@group.calendar.google.com",
+      "name": "Exercise",
+      "color": {
+        "id": "9",
+        "background": "#7bd148",
+        "foreground": "#000000"
+      }
+    }
+  }, {
+    "id": "1s1ojcm0ie1c7jepvslkrm742o_20170407T060000Z",
+    "status": "confirmed",
+    "htmlLink": "https://www.google.com/calendar/event?eid=MXMxb2pjbTBpZTFjN2plcHZzbGtybTc0Mm9fMjAxNzA0MDdUMDYwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "created": 1490637918,
+    "updated": 1490780809,
+    "summary": "Time to take your morning medicine",
+    "description": "Blue box, on the kitchen counter.",
+    "location": "Home",
+    "creator": "proiect.cami@gmail.com",
+    "start": 1491544800,
+    "end": 1491545400,
+    "sequence": 0,
+    "reminders": {
+      "useDefault": true
+    },
+    "calendar": {
+      "id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+      "name": "Medication",
+      "color": {
+        "id": "4",
+        "background": "#fa573c",
+        "foreground": "#000000"
+      }
+    }
+  }, {
     "id": "27uieel2459rd4oeu4f6c8njds",
     "status": "confirmed",
     "htmlLink": "https://www.google.com/calendar/event?eid=Mjd1aWVlbDI0NTlyZDRvZXU0ZjZjOG5qZHMgZzgyMnJsMTRvc2pjNzVtZjg4bG92Y2k2a2dAZw",
     "created": 1489494516,
-    "updated": 1489494516,
+    "updated": 1490781198,
     "summary": "Checkup with Dr. Forrester",
     "description": "Find out how your blood work tests went.",
     "location": "Mills Heights Clinic",
     "creator": "proiect.cami@gmail.com",
-    "start": 1495009800,
-    "end": 1495011600,
+    "start": 1491553800,
+    "end": 1491555600,
     "sequence": 0,
     "reminders": {
       "useDefault": true

--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -27,25 +27,28 @@ const ActivitiesView = React.createClass({
   render() {
     const today = moment();
     const todayMonth = today.format('MMM');
-    const firstEventDate = moment.unix(this.props.events.get(0).get('start'));
+    // DEMO(@rtud): replace index w/ 0
+    const firstEventDate = moment.unix(this.props.events.get(3).get('start'));
     const firstEventMonth = firstEventDate ? firstEventDate.format('MMM') : false;
 
     const events = [];
-    let monthKey = firstEventMonth;
+    // DEMO(@rtud): should be firstMonth index
+    let monthKey = moment.unix(this.props.events.get(3).get('start') + 420000).format('MMMM');
 
     this.props.events.forEach((event, index) => {
       // we want to exclude the 1st event
       // -- we're already displaying it inside the Activities Header
-      if (index > 0) {
+      // -- DEMO(@rtud): replace comparison w/ '>'
+      if (index >= 0) {
         // every time a month changes we show a visual separator inside the timeline
-        const month = moment.unix(event.get('start')).format('MMM');
+        // - DEMO(@rtud): altered so we can push dates up
+        const month = index < 3 ? moment.unix(event.get('start')).format('MMMM') : moment.unix(event.get('start') + 420000).format('MMMM');
         if (month != monthKey) {
           monthKey = month;
-          const monthSeparatorText = moment.unix(event.get('start')).format('MMMM');
           events.push(
             <View key={'text' + index} style={[styles.dateContainer, {flex: 1}]}>
               <View style={styles.dateRuler}><View style={styles.dateBullet}/></View>
-              <Text style={[styles.date]}>{monthSeparatorText}</Text>
+              <Text style={[styles.date]}>{month}</Text>
             </View>
           );
         }
@@ -56,7 +59,7 @@ const ActivitiesView = React.createClass({
         events.push(
           <ActivityEntry
             key={'entry' + index}
-            timestamp={event.get('start')}
+            timestamp={index < 3 ? event.get('start') : event.get('start') + 432000}
             title={event.get('summary')}
             description={event.get('description')}
             location={event.get('location')}
@@ -66,6 +69,7 @@ const ActivitiesView = React.createClass({
       }
     });
 
+    // DEMO(@rtud): replace index w/ 0 below after demo
     return (
       <View style={variables.container}>
         <View style={styles.headerContainer}>
@@ -103,13 +107,13 @@ const ActivitiesView = React.createClass({
               </View>
             </View>
             {
-              this.props.events.get(0).get('summary')
-                ? <Text style={styles.nextTitle}>{this.props.events.get(0).get('summary')}</Text>
+              this.props.events.get(3).get('summary')
+                ? <Text style={styles.nextTitle}>{this.props.events.get(3).get('summary')}</Text>
                 : <Text style={styles.nextTitle}>No pending events</Text>
             }
             {
-              this.props.events.get(0).get('description')
-                ? <Text style={styles.nextDescription}>{this.props.events.get(0).get('description')}</Text>
+              this.props.events.get(3).get('description')
+                ? <Text style={styles.nextDescription}>{this.props.events.get(3).get('description')}</Text>
                 : <Text style={styles.nextDescription}>Add using Google Calendar</Text>
             }
             <View style={styles.nextMeta}>
@@ -134,8 +138,8 @@ const ActivitiesView = React.createClass({
               />
               <View style={styles.nextLocation}>
                 {
-                  this.props.events.get(0).get('location')
-                    ? <Text style={styles.metaText}>{this.props.events.get(0).get('location')}</Text>
+                  this.props.events.get(3).get('location')
+                    ? <Text style={styles.metaText}>{this.props.events.get(3).get('location')}</Text>
                     : <Text style={styles.metaText}>----</Text>
                 }
               </View>

--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -71,6 +71,8 @@ const ActivitiesView = React.createClass({
             description={event.get('description')}
             location={event.get('location')}
             color={event.get('calendar').get('color').get('background')}
+            archived={index < 3 ? true : false}
+            today={index === 3 ? true : false}
           />
         );
       }

--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -51,6 +51,8 @@ const ActivitiesView = React.createClass({
         }
 
         // and now let's build that event list
+        // - TODO(@rtud): color gets passed as hex value for now
+        //   - we should create a local mappging of gCal registered colors
         events.push(
           <ActivityEntry
             key={'entry' + index}
@@ -58,6 +60,7 @@ const ActivitiesView = React.createClass({
             title={event.get('summary')}
             description={event.get('description')}
             location={event.get('location')}
+            color={event.get('calendar').get('color').get('background')}
           />
         );
       }

--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -24,6 +24,13 @@ const ActivitiesView = React.createClass({
     username: PropTypes.string.isRequired,
   },
 
+  componentDidMount() {
+    const _scrollView = this.scrollView;
+    // TODO(@rtud): scrollTo shouldn't hard coded value
+    // - we should grab one of the Entry's height
+    _scrollView.scrollTo({x:0, y: 578, animated: true});
+  },
+
   render() {
     const today = moment();
     const todayMonth = today.format('MMM');
@@ -149,7 +156,10 @@ const ActivitiesView = React.createClass({
 
         <View style={styles.timeline}></View>
 
-        <ScrollView style={styles.eventsContainer}>
+        <ScrollView
+          style={styles.eventsContainer}
+          ref={scrollView => this.scrollView = scrollView}
+        >
           {/*
             Later on we'll be adding Pull to Refresh behaviour
             -- just like we're doing for the Journal screen

--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -122,7 +122,7 @@ const ActivitiesView = React.createClass({
               <View style={styles.nextTime}>
                 {
                   firstEventDate
-                    ? <Text style={styles.metaText}>{firstEventDate.format('hh:mm')}</Text>
+                    ? <Text style={styles.metaText}>{firstEventDate.format('HH:mm')}</Text>
                     : <Text style={styles.metaText}>--:--</Text>
                 }
               </View>

--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -73,7 +73,14 @@ const ActivitiesView = React.createClass({
             <View>
               {
                 firstEventDate
-                  ? <Text style={styles.day}>{firstEventDate.format('DD').toUpperCase()}</Text>
+                  ? <Text style={styles.dayName}>{firstEventDate.format('ddd')}</Text>
+                  : <Text style={styles.dayName}>--</Text>
+              }
+            </View>
+            <View>
+              {
+                firstEventDate
+                  ? <Text style={styles.day}>{firstEventDate.format('DD')}</Text>
                   : <Text style={styles.day}>--</Text>
               }
             </View>
@@ -171,6 +178,13 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: variables.colors.status.ok
+  },
+  dayName: {
+    color: 'white',
+    fontSize: 12,
+    fontWeight: 'bold',
+    lineHeight: 18,
+    marginBottom: 5
   },
   day: {
     color: 'white',

--- a/application/src/modules/activities/components/ActivityEntry.js
+++ b/application/src/modules/activities/components/ActivityEntry.js
@@ -6,6 +6,7 @@ import {
 } from 'react-native';
 
 import moment from 'moment';
+import Color from 'color';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import icons from 'Cami/src/icons-fa';
 import variables from '../../variables/CaregiverGlobalVariables';
@@ -17,29 +18,38 @@ const ActivityEntry = React.createClass({
     description: PropTypes.string.isRequired,
     location: PropTypes.string.isRequired,
     color: PropTypes.string.isRequired,
+    archived: PropTypes.bool.isRequired,
+    today: PropTypes.bool.isRequired,
   },
 
   render() {
     const eventTime = moment.unix(this.props.timestamp);
 
     return (
-      <View style={styles.activityEntry}>
+      <View style={[
+        styles.activityEntry,
+        {
+          opacity: this.props.archived ? 0.5 : 1,
+          backgroundColor: !this.props.today ? 'white' : Color(variables.colors.status.ok).clearer(.25).rgbaString()
+        }
+      ]}>
         <View style={styles.dateContainer}>
           <View>
-            <Text style={styles.dayName}>{eventTime.format('ddd')}</Text>
+            <Text style={[styles.dayName, {color: !this.props.today ? variables.colors.gray.dark : 'white'}]}>{eventTime.format('ddd')}</Text>
           </View>
           <View>
-            <Text style={styles.day}>{eventTime.format('DD')}</Text>
+            <Text style={[styles.day, {color: !this.props.today ? variables.colors.gray.dark : 'white'}]}>{eventTime.format('DD')}</Text>
           </View>
           <View>
-            <Text style={styles.month}>{eventTime.format('MMM').toUpperCase()}</Text>
+            <Text style={[styles.month, {color: !this.props.today ? variables.colors.gray.dark : 'white'}]}>{eventTime.format('MMM').toUpperCase()}</Text>
           </View>
         </View>
 
         <View style={{
           flex: 7,
           borderLeftWidth: 2,
-          borderColor: this.props.color
+          borderColor: !this.props.archived ? this.props.color : variables.colors.gray.neutral,
+          backgroundColor: 'white'
         }}>
           <View style={styles.textContainer}>
             <View style={{flexWrap: 'wrap'}}>
@@ -84,6 +94,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'flex-start',
     alignItems: 'center',
+  },
+  archived: {
+    opacity: 0.75
   },
   dateContainer: {
     width: 80,

--- a/application/src/modules/activities/components/ActivityEntry.js
+++ b/application/src/modules/activities/components/ActivityEntry.js
@@ -16,6 +16,7 @@ const ActivityEntry = React.createClass({
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     location: PropTypes.string.isRequired,
+    color: PropTypes.string.isRequired,
   },
 
   render() {
@@ -35,7 +36,7 @@ const ActivityEntry = React.createClass({
         <View style={{
           flex: 7,
           borderLeftWidth: 2,
-          borderColor: variables.colors.gray.neutral
+          borderColor: this.props.color
         }}>
           <View style={styles.textContainer}>
             <View style={{flexWrap: 'wrap'}}>

--- a/application/src/modules/activities/components/ActivityEntry.js
+++ b/application/src/modules/activities/components/ActivityEntry.js
@@ -58,7 +58,7 @@ const ActivityEntry = React.createClass({
                 style={{paddingRight: 5}}
               />
               <View>
-                <Text style={styles.metaText}>{eventTime.format('hh:mm')}</Text>
+                <Text style={styles.metaText}>{eventTime.format('HH:mm')}</Text>
               </View>
               <Icon
                 name={icons.location}

--- a/application/src/modules/activities/components/ActivityEntry.js
+++ b/application/src/modules/activities/components/ActivityEntry.js
@@ -26,6 +26,9 @@ const ActivityEntry = React.createClass({
       <View style={styles.activityEntry}>
         <View style={styles.dateContainer}>
           <View>
+            <Text style={styles.dayName}>{eventTime.format('ddd')}</Text>
+          </View>
+          <View>
             <Text style={styles.day}>{eventTime.format('DD')}</Text>
           </View>
           <View>
@@ -92,6 +95,12 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     alignItems: 'center',
     zIndex: 7,
+  },
+  dayName: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    color: variables.colors.gray.dark,
+    marginBottom: 5
   },
   day: {
     fontSize: 26,


### PR DESCRIPTION
## Why
For the purpose of the consortium demo in the coming week, we need to be able to switch between users on the iOS app.

Due to the fact that we'll be unable to finish #189 in time for the demo, we won't be able to connect the Activities screen to real data just yet. Instead we'll improve the current static implementation so that it better reflects the desired end-product.

## What
* [x] the mock JSON used for displaying the activities is updated, so that it also includes the following information:
   * [x] events feature information on the calendar they belongs to
   * [x] additional events are added to the JSON, so that we cover the following use cases:
       * [x] medication reminders
       * [x] exercise reminders
       * [x] appointments
* [x] the design of events on the Activities screen is updated, so each event will feature a coloured element corresponding to the calendar it belongs to

## Notes
