### PR TITLE
Periodically synchronize users activities from Google Calendar

### DIFF
--- a/Dockerfile-store-management
+++ b/Dockerfile-store-management
@@ -15,11 +15,15 @@ COPY docker/cami-store/docker-entrypoint.sh /usr/local/bin/
 COPY docker/cami-store/docker-migration-entrypoint.sh /usr/local/bin/
 COPY docker/cami-store/docker-message-worker-entrypoint.sh /usr/local/bin/
 COPY docker/cami-store/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
+COPY docker/cami-store/docker-task-scheduler-entrypoint.sh /usr/local/bin/
+COPY docker/cami-store/docker-task-scheduler-entrypoint-dev.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-migration-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-message-worker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-message-worker-entrypoint-dev.sh
+RUN chmod +x /usr/local/bin/docker-task-scheduler-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-task-scheduler-entrypoint-dev.sh
 
 RUN adduser --disabled-password --gecos '' storemgr
 RUN chown -R storemgr /cami-project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,19 @@ services:
       - .:/cami-project
     entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-message-worker-entrypoint-dev.sh
 
+  # Runs the Celery task scheduler for store-management
+  cami-store-management-task-scheduler:
+    build:
+      context: .
+      dockerfile: Dockerfile-store-management
+    links:
+      # Needs the store to interact with the DB
+      - cami-store
+      - cami-rabbitmq
+    volumes:
+      - .:/cami-project
+    entrypoint: ./docker/lib/wait-for-it/wait-for-it.sh -s -t 30 cami-store:3306 -- docker-task-scheduler-entrypoint-dev.sh
+
   cami-rabbitmq:
     build:
       context: .

--- a/docker/cami-store/docker-task-scheduler-entrypoint-dev.sh
+++ b/docker/cami-store/docker-task-scheduler-entrypoint-dev.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Export root of cami-project to PYTHONPATH, to make all services accessible as modules
+export PYTHONPATH="${PYTHONPATH}:/cami-project"
+
+# Start a celery worker for the store app.
+cd /cami-project/store
+python run_celery_beat.py store
+

--- a/docker/cami-store/docker-task-scheduler-entrypoint.sh
+++ b/docker/cami-store/docker-task-scheduler-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Export root of cami-project to PYTHONPATH, to make all services accessible as modules
+export PYTHONPATH="${PYTHONPATH}:/cami-project"
+
+# Start a celery worker for the store app.
+cd /cami-project/store
+celery -A store beat -l info

--- a/store/run_celery_beat.py
+++ b/store/run_celery_beat.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""Runs a celery worker, and reloads on a file change. Run as ./run_celery [directory]. If
+directory is not given, default to cwd."""
+import os
+import sys
+import signal
+import time
+
+import multiprocessing
+import subprocess
+import threading
+
+import inotify.adapters
+
+
+CELERY_CMD = tuple("celery -A store beat -l info".split())
+CHANGE_EVENTS = ("IN_MODIFY", "IN_ATTRIB", "IN_DELETE")
+WATCH_EXTENSIONS = (".py",)
+
+def watch_tree(stop, path, event):
+    """
+    @type stop: multiprocessing.Event
+    @type event: multiprocessing.Event
+    """
+    path = os.path.abspath(path)
+
+    for e in inotify.adapters.InotifyTree(path).event_gen():
+        if stop.is_set():
+            break
+
+        if e is not None:
+            _, attrs, path, filename = e
+
+            if filename is None:
+                continue
+
+            if any(filename.endswith(ename) for ename in WATCH_EXTENSIONS):
+                continue
+
+            if any(ename in attrs for ename in CHANGE_EVENTS):
+                event.set()
+
+
+class Watcher(threading.Thread):
+    def __init__(self, path):
+        super(Watcher, self).__init__()
+        self.celery = subprocess.Popen(CELERY_CMD)
+        self.stop_event_wtree = multiprocessing.Event()
+        self.event_triggered_wtree = multiprocessing.Event()
+        self.wtree = multiprocessing.Process(target=watch_tree, args=(self.stop_event_wtree, path, self.event_triggered_wtree))
+        self.wtree.start()
+        self.running = True
+
+    def run(self):
+        while self.running:
+            if self.event_triggered_wtree.is_set():
+                self.event_triggered_wtree.clear()
+                self.restart_celery()
+            time.sleep(1)
+
+    def join(self, timeout=None):
+        self.running = False
+        self.stop_event_wtree.set()
+        self.celery.terminate()
+        self.wtree.join()
+        self.celery.wait()
+        super(Watcher, self).join(timeout=timeout)
+
+    def restart_celery(self):
+        self.celery.terminate()
+        self.celery.wait()
+        self.celery = subprocess.Popen(CELERY_CMD)
+
+
+if __name__ == '__main__':
+    watcher = Watcher(sys.argv[1] if len(sys.argv) > 1 else ".")
+    watcher.start()
+
+    signal.signal(signal.SIGINT, lambda signal, frame: watcher.join())
+    signal.pause()

--- a/store/store/activities.py
+++ b/store/store/activities.py
@@ -1,6 +1,7 @@
 import pytz
 import time
 import datetime
+import calendar
 import dateutil.parser
 
 from .google_calendar_backend import *
@@ -181,7 +182,7 @@ def event_equals_activity(event, activity):
     return True
 
 def timestamp_from_event_date(date):
-    return time.mktime(
-        dateutil.parser.parse(date).timetuple()
+    return calendar.timegm(
+        dateutil.parser.parse(date).utctimetuple()
     )
 

--- a/store/store/activities.py
+++ b/store/store/activities.py
@@ -110,9 +110,14 @@ def process_events(user, calendar, events, date_from, date_to):
             # Remove the DB event from the hash because it is valid
             db_events_hash.pop(event['id'], None)
 
+            # The calendar color might have changed, add it to the event
+            # in order to be compared with the activity color
+            event['color'] = calendar_colors
+
             # If the event does not differ from the already stored
             # activity then continue with the next event
             if event_equals_activity(event, db_event) == True:
+                logger.debug("[sync-activities] Events are equal")
                 continue
 
             # The event differs from the already stored activity so add
@@ -164,7 +169,16 @@ def compose_activity_data(event, calendar, calendar_colors, user):
     return activity_data
 
 def event_equals_activity(event, activity):
-    return False
+    # Compare color
+    if event['color'] != activity['color']:
+        return False
+
+    # Compare update time
+    event_updated_timestamp = timestamp_from_event_date(event['updated'])
+    if event_updated_timestamp != activity['updated']:
+        return False
+
+    return True
 
 def timestamp_from_event_date(date):
     return time.mktime(

--- a/store/store/settings.py
+++ b/store/store/settings.py
@@ -204,9 +204,9 @@ STATIC_URL = '/static/'
 ## CELERY settings
 BROKER_URL = 'amqp://cami:cami@cami-rabbitmq:5672/cami'
 
-CELERY_DEFAULT_QUEUE = 'store'
+CELERY_DEFAULT_QUEUE = 'store_activities_sync'
 CELERY_QUEUES = (
-    Queue('store', Exchange('store'), routing_key='store'),
+    Queue('store_activities_sync', Exchange('store_activities_sync'), routing_key='store_activities_sync'),
 )
 
 

--- a/store/store/settings.py
+++ b/store/store/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 import os
 import raven
 
+from datetime import timedelta
 from kombu import Exchange, Queue
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -200,6 +201,13 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+## Sync Google Calendar Events Scheduled Task
+CELERYBEAT_SCHEDULE = {
+    'sync_activities': {
+        'task': 'store.sync_activities',
+        'schedule': timedelta(minutes=5),
+    },
+}
 
 ## CELERY settings
 BROKER_URL = 'amqp://cami:cami@cami-rabbitmq:5672/cami'

--- a/store/store/tasks.py
+++ b/store/store/tasks.py
@@ -22,8 +22,6 @@ def sync_activities():
     user = User.objects.get(username="camidemo")
     app.send_task('store.sync_activities_for_user', [user])
 
-    logger.debug("[sync-activities] Finished synchronizing all users activities with Google Calendar!")
-
 @app.task(name='store.sync_activities_for_user')
 def sync_activities_for_user(user):
     activities.sync_for_user(user)


### PR DESCRIPTION
## Why
This is a follow up of #189. In order to integrate CAMI system with Google Calendar, we need to keep users events from Google Calendar in sync with the activities from our system.

## What
- [x] Run the Celery task implemented in #210 every 5 minutes

## Notes
