### PR TITLE
Revert hard coded Activity screen values used for the DEMO

### DIFF
--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -34,22 +34,18 @@ const ActivitiesView = React.createClass({
   render() {
     const today = moment();
     const todayMonth = today.format('MMM');
-    // DEMO(@rtud): replace index w/ 0
-    const firstEventDate = moment.unix(this.props.events.get(3).get('start') + 86400);
+    const firstEventDate = moment.unix(this.props.events.get(0).get('start'));
     const firstEventMonth = firstEventDate ? firstEventDate.format('MMM') : false;
 
     const events = [];
-    // DEMO(@rtud): should be firstMonth index
-    let monthKey = moment.unix(this.props.events.get(3).get('start') + 432000).format('MMMM');
+    let monthKey = firstEventMonth;
 
     this.props.events.forEach((event, index) => {
       // we want to exclude the 1st event
       // -- we're already displaying it inside the Activities Header
-      // -- DEMO(@rtud): replace comparison w/ '>'
-      if (index >= 0) {
+      if (index > 0) {
         // every time a month changes we show a visual separator inside the timeline
-        // - DEMO(@rtud): altered so we can push dates up
-        const month = index <= 3 ? moment.unix(event.get('start') + 86400).format('MMMM') : moment.unix(event.get('start') + 432000).format('MMMM');
+        const month = moment.unix(event.get('start')).format('MMMM');
         if (month != monthKey) {
           monthKey = month;
           events.push(
@@ -66,19 +62,18 @@ const ActivitiesView = React.createClass({
         events.push(
           <ActivityEntry
             key={'entry' + index}
-            timestamp={index <= 3 ? event.get('start') + 86400 : event.get('start') + 432000}
+            timestamp={event.get('start')}
             title={event.get('summary')}
             description={event.get('description')}
             location={event.get('location')}
             color={event.get('calendar').get('color').get('background')}
-            archived={index < 3 ? true : false}
-            today={index == 3 ? true : false}
+            archived={false}
+            today={false}
           />
         );
       }
     });
 
-    // DEMO(@rtud): replace index w/ 0 below after demo
     return (
       <View style={variables.container}>
         <View style={styles.headerContainer}>
@@ -116,13 +111,13 @@ const ActivitiesView = React.createClass({
               </View>
             </View>
             {
-              this.props.events.get(3).get('summary')
-                ? <Text style={styles.nextTitle}>{this.props.events.get(3).get('summary')}</Text>
+              this.props.events.get(0).get('summary')
+                ? <Text style={styles.nextTitle}>{this.props.events.get(0).get('summary')}</Text>
                 : <Text style={styles.nextTitle}>No pending events</Text>
             }
             {
-              this.props.events.get(3).get('description')
-                ? <Text style={styles.nextDescription}>{this.props.events.get(3).get('description')}</Text>
+              this.props.events.get(0).get('description')
+                ? <Text style={styles.nextDescription}>{this.props.events.get(0).get('description')}</Text>
                 : <Text style={styles.nextDescription}>Add using Google Calendar</Text>
             }
             <View style={styles.nextMeta}>
@@ -147,8 +142,8 @@ const ActivitiesView = React.createClass({
               />
               <View style={styles.nextLocation}>
                 {
-                  this.props.events.get(3).get('location')
-                    ? <Text style={styles.metaText}>{this.props.events.get(3).get('location')}</Text>
+                  this.props.events.get(0).get('location')
+                    ? <Text style={styles.metaText}>{this.props.events.get(0).get('location')}</Text>
                     : <Text style={styles.metaText}>----</Text>
                 }
               </View>


### PR DESCRIPTION
## Why
For the demo on March 31st, given that there wasn't enough time to present a working Google Calendar integration via the API, in #190 we had to resort to a series of hacks that would make the app look and feel like it made use of dynamic data.

In order to prepare the application to display dynamic data for #187, we need to remove those hacks.

## What
* [x] the hacks used for displaying static data in #190, are removed, ensuring that:
   * [x] the back-dated events hack is removed
   * [ ] the height offset for back-dated events hack is removed
   * [x] assigning of current date events hack is removed
   * [x] the month separator hack is removed

## Notes
