### PR TITLE
Adapt Activities screen to display data from API

### DIFF
--- a/application/api-examples/activities/google-calendar-feed-from-api.json
+++ b/application/api-examples/activities/google-calendar-feed-from-api.json
@@ -1,0 +1,137 @@
+[
+  {
+    "activity_type": "medication",
+    "calendar_id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+    "calendar_name": "Medication",
+    "color": {
+      "background": "#fa573c",
+      "foreground": "#000000",
+      "id": "4"
+    },
+    "created": 1494413636,
+    "creator": {
+      "email": "proiect.cami@gmail.com"
+    },
+    "description": null,
+    "end": 1494504000,
+    "event_id": "h5bk4mchboa9od1uroe93nthi8_20170511T110000Z",
+    "html_link": "https://www.google.com/calendar/event?eid=aDViazRtY2hib2E5b2QxdXJvZTkzbnRoaThfMjAxNzA1MTFUMTEwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "iCalUID": "h5bk4mchboa9od1uroe93nthi8@google.com",
+    "id": 7,
+    "recurring_event_id": "h5bk4mchboa9od1uroe93nthi8",
+    "reminders": {},
+    "start": 1494500400,
+    "status": "confirmed",
+    "title": "Analgezics",
+    "updated": 1494413636,
+    "user_id": 2
+  },
+  {
+    "activity_type": "exercise",
+    "calendar_id": "8puar0sc4e7efns5r849rn0lus@group.calendar.google.com",
+    "calendar_name": "Exercise",
+    "color": {
+      "background": "#7bd148",
+      "foreground": "#000000",
+      "id": "9"
+    },
+    "created": 1494535962,
+    "creator": {
+      "email": "proiect.cami@gmail.com"
+    },
+    "description": null,
+    "end": 1494511200,
+    "event_id": "19c584tf0u6r1iprrkggrq6il4",
+    "html_link": "https://www.google.com/calendar/event?eid=MTljNTg0dGYwdTZyMWlwcnJrZ2dycTZpbDQgOHB1YXIwc2M0ZTdlZm5zNXI4NDlybjBsdXNAZw",
+    "iCalUID": "19c584tf0u6r1iprrkggrq6il4@google.com",
+    "id": 9,
+    "recurring_event_id": null,
+    "reminders": {},
+    "start": 1494507600,
+    "status": "confirmed",
+    "title": "Crunches",
+    "updated": 1494537052,
+    "user_id": 2
+  },
+  {
+    "activity_type": "personal",
+    "calendar_id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+    "calendar_name": "Appointments",
+    "color": {
+      "background": "#fbe983",
+      "foreground": "#000000",
+      "id": "11"
+    },
+    "created": 1494544314,
+    "creator": {
+      "email": "proiect.cami@gmail.com"
+    },
+    "description": null,
+    "end": 1494603000,
+    "event_id": "pjm35ld41grfhrfh93472j1g24",
+    "html_link": "https://www.google.com/calendar/event?eid=cGptMzVsZDQxZ3JmaHJmaDkzNDcyajFnMjQgN2VoNnFuaXZpZDY0MzBkbDc5ZWk4OWsyNmdAZw",
+    "iCalUID": "pjm35ld41grfhrfh93472j1g24@google.com",
+    "id": 5,
+    "recurring_event_id": null,
+    "reminders": {},
+    "start": 1494599400,
+    "status": "confirmed",
+    "title": "Tennis w/ Joel",
+    "updated": 1494552610,
+    "user_id": 2
+  },
+  {
+    "activity_type": "personal",
+    "calendar_id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+    "calendar_name": "Appointments",
+    "color": {
+      "background": "#fbe983",
+      "foreground": "#000000",
+      "id": "11"
+    },
+    "created": 1494556425,
+    "creator": {
+      "email": "proiect.cami@gmail.com"
+    },
+    "description": null,
+    "end": 1494689400,
+    "event_id": "nd044tjlq84a3cl0hpcgu4ck6g",
+    "html_link": "https://www.google.com/calendar/event?eid=bmQwNDR0amxxODRhM2NsMGhwY2d1NGNrNmcgN2VoNnFuaXZpZDY0MzBkbDc5ZWk4OWsyNmdAZw",
+    "iCalUID": "nd044tjlq84a3cl0hpcgu4ck6g@google.com",
+    "id": 6,
+    "recurring_event_id": null,
+    "reminders": {},
+    "start": 1494685800,
+    "status": "confirmed",
+    "title": "Footbal Game",
+    "updated": 1494556425,
+    "user_id": 2
+  },
+  {
+    "activity_type": "medication",
+    "calendar_id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+    "calendar_name": "Medication",
+    "color": {
+      "background": "#fa573c",
+      "foreground": "#000000",
+      "id": "4"
+    },
+    "created": 1494413636,
+    "creator": {
+      "email": "proiect.cami@gmail.com"
+    },
+    "description": null,
+    "end": 1495108800,
+    "event_id": "h5bk4mchboa9od1uroe93nthi8_20170518T110000Z",
+    "html_link": "https://www.google.com/calendar/event?eid=aDViazRtY2hib2E5b2QxdXJvZTkzbnRoaThfMjAxNzA1MThUMTEwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "iCalUID": "h5bk4mchboa9od1uroe93nthi8@google.com",
+    "id": 8,
+    "recurring_event_id": "h5bk4mchboa9od1uroe93nthi8",
+    "reminders": {},
+    "start": 1495105200,
+    "status": "confirmed",
+    "title": "Analgezics",
+    "updated": 1494413636,
+    "user_id": 2
+  }
+]

--- a/application/env.example.js
+++ b/application/env.example.js
@@ -7,6 +7,7 @@ module.exports = {
   AUTH0_DOMAIN: 'vitamin.eu.auth0.com',
   POLL_INTERVAL_MILLIS: 5000,
   NOTIFICATIONS_REST_API: 'http://cami.vitaminsoftware.com:8001/api/v1/notifications/',
+  ACTIVITIES_LAST_EVENTS: 'http://cami.vitaminsoftware.com:8008/api/v1/activity/last_activities/',
   WEIGHT_MEASUREMENTS_LAST_VALUES: 'http://cami.vitaminsoftware.com:8000/api/v1/weight-measurements/last_values/',
   HEARTRATE_MEASUREMENTS_LAST_VALUES: 'http://cami.vitaminsoftware.com:8000/api/v1/heartrate-measurements/last_values/',
   STEPS_MEASUREMENTS_LAST_VALUES: 'http://cami.vitaminsoftware.com:8000/api/v1/steps-measurements/last_values/',

--- a/application/src/modules/activities/ActivitiesState.js
+++ b/application/src/modules/activities/ActivitiesState.js
@@ -1,6 +1,6 @@
 import {fromJS} from 'immutable';
 
-var json = require('../../../api-examples/activities/google-calendar-feed.json');
+var json = require('../../../api-examples/activities/google-calendar-feed-from-api.json');
 
 // Initial State
 const initialState = fromJS(json);

--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -64,10 +64,10 @@ const ActivitiesView = React.createClass({
           <ActivityEntry
             key={'entry' + index}
             timestamp={event.get('start')}
-            title={event.get('summary')}
-            description={event.get('description')}
-            location={event.get('location')}
-            color={event.get('calendar').get('color').get('background')}
+            title={event.get('title')}
+            description={event.get('description') !== null ? event.get('description') : 'No description'}
+            location={'No location set'}
+            color={event.get('color').get('background')}
             archived={false}
             today={false}
           />
@@ -112,12 +112,12 @@ const ActivitiesView = React.createClass({
               </View>
             </View>
             {
-              this.props.events.get(0).get('summary')
-                ? <Text style={styles.nextTitle}>{this.props.events.get(0).get('summary')}</Text>
+              this.props.events.get(0).get('title') !== null
+                ? <Text style={styles.nextTitle}>{this.props.events.get(0).get('title')}</Text>
                 : <Text style={styles.nextTitle}>No pending events</Text>
             }
             {
-              this.props.events.get(0).get('description')
+              this.props.events.get(0).get('description') !== null
                 ? <Text style={styles.nextDescription}>{this.props.events.get(0).get('description')}</Text>
                 : <Text style={styles.nextDescription}>Add using Google Calendar</Text>
             }

--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -143,9 +143,11 @@ const ActivitiesView = React.createClass({
               />
               <View style={styles.nextLocation}>
                 {
+                  <Text style={styles.metaText}>----</Text>
+                  /* TODO (@rtud): uncomment after inclusion of event location data in API response
                   this.props.events.get(0).get('location')
                     ? <Text style={styles.metaText}>{this.props.events.get(0).get('location')}</Text>
-                    : <Text style={styles.metaText}>----</Text>
+                    : <Text style={styles.metaText}>----</Text> */
                 }
               </View>
             </View>

--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -28,7 +28,8 @@ const ActivitiesView = React.createClass({
     const _scrollView = this.scrollView;
     // TODO(@rtud): scrollTo shouldn't hard coded value
     // - we should grab one of the Entry's height
-    _scrollView.scrollTo({x:0, y: 558, animated: true});
+    // - uncomment and reuse in #215
+    // _scrollView.scrollTo({x:0, y: 558, animated: true});
   },
 
   render() {

--- a/application/src/modules/activities/ActivitiesViewContainer.js
+++ b/application/src/modules/activities/ActivitiesViewContainer.js
@@ -5,6 +5,6 @@ import ActivitiesView from './ActivitiesView';
 export default connect(
   state => ({
     username: state.getIn(['auth', 'currentUser', 'name']),
-    events: state.getIn(['activities', 'events'])
+    events: state.getIn(['homepageCaregiver', 'lastActivities'])
   })
 )(ActivitiesView);

--- a/application/src/modules/activities/components/ActivityEntry.js
+++ b/application/src/modules/activities/components/ActivityEntry.js
@@ -14,10 +14,10 @@ import variables from '../../variables/CaregiverGlobalVariables';
 const ActivityEntry = React.createClass({
   propTypes: {
     timestamp: PropTypes.number.isRequired,
-    title: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired,
-    location: PropTypes.string.isRequired,
-    color: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    description: PropTypes.string,
+    location: PropTypes.string,
+    color: PropTypes.string,
     archived: PropTypes.bool.isRequired,
     today: PropTypes.bool.isRequired,
   },


### PR DESCRIPTION
## Why
In #157 we've added the Activities screen to the iOS application, that used a HC data json to display events.

Following the progress made by @cretualexandru in #210, #211 & #212 the API is now setup to grab real events via Google Calendar's API and expose them to the CAMI system's clients.

## What
* [x] the iOS application is adapted to fetch the events from the API
* [x] the Activities screen is adapted to display the fetched events  

## Notes
Part of #187.