### PR TITLE
Document the Activity API endpoint

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -118,7 +118,7 @@ Example:
 $ curl -i http://cami.vitaminsoftware.com:8001/api/v1/healthcheck/
 HTTP/1.0 200 OK
 Date: Fri, 24 Mar 2017 17:17:41 GMT
-Server: WSGIServer/0.1CAMI Cloud integrates with the Google Fit API for gathering steps & hear rate measurements. Here's what's needed to test if measurements are processed accordingly throughout the CAMI Cloud system: Python/2.7.12
+Server: WSGIServer/0.1 Python/2.7.12
 Vary: Accept
 X-Frame-Options: ALLOW-FROM *
 Content-Type: application/json

--- a/TESTING.md
+++ b/TESTING.md
@@ -94,6 +94,23 @@ datastream_id: derived:com.google.step_count.delta:com.google.android.gms:LGE:LG
 
 We will be using the dedicated LG Watch datasource for the moment.
 
+
+## Testing Google Calendar activities
+CAMI Cloud integrates with the Google Calendar API for gathering events from some predefined calendars. Here's what's needed to test if calendar events are processed accordingly throughout the CAMI Cloud system:
+
+- Visit Google Calendar and login using the credentials stored in LastPass
+- There are 3 calendars that are synchronized with CAMI:
+	- Appointments
+	- Exercise
+	- Medication
+- Add events in the calendars described above, on a maximum timeframe of 7 days in the past and 7 days in the future. Any event that will be older than 7 days or more than 7 days away from now will not be sync-ed in the system.
+- Manually synchronize the activities from Google Calendar (described [here](https://github.com/cami-project/cami-project/blob/master/store/README.md#activities))
+- The newly entered event will now be fetched and processed by the CAMI Cloud and show up on the various systems connected to it, like:
+	- the Papertrail logging system - credentials to access it are stored inside LastPass
+	- the CAMI iOS application
+	- the activities endpoints (described [here](https://github.com/cami-project/cami-project/blob/master/store/README.md#activities))
+
+
 ## Testing APIs
 Check - with cURL, from command line - the following API endpoints to be up and running.
 Example:
@@ -101,7 +118,7 @@ Example:
 $ curl -i http://cami.vitaminsoftware.com:8001/api/v1/healthcheck/
 HTTP/1.0 200 OK
 Date: Fri, 24 Mar 2017 17:17:41 GMT
-Server: WSGIServer/0.1 Python/2.7.12
+Server: WSGIServer/0.1CAMI Cloud integrates with the Google Fit API for gathering steps & hear rate measurements. Here's what's needed to test if measurements are processed accordingly throughout the CAMI Cloud system: Python/2.7.12
 Vary: Accept
 X-Frame-Options: ALLOW-FROM *
 Content-Type: application/json

--- a/store/README.md
+++ b/store/README.md
@@ -277,7 +277,7 @@ __Weight__:
 }
 ```
 
-### Activities:
+#### Activities:
 
 - full endpoint:
 ```
@@ -336,6 +336,7 @@ http://cami.vitaminsoftware.com:8008/api/v1/activity/
 ```
 
 - last activities endpoint:
+
 Currently, this retrieves the activities from 7 days in the past and 7 days in the future from the current time(14 days totally), for ALL the users. There is information only for one hardcoded user, though. This will have to be modified to accept a user parameter, in order to be able to retrieve information only for one user.
 
 This is how it looks like:

--- a/store/README.md
+++ b/store/README.md
@@ -14,6 +14,7 @@ The set of currently implemented endpoints allows to:
   * filter the list of Measurements by: device_id, user_id, measurement type, timestamp,
   value and context information
   * insert a new measurement
+  * get the list of Activities for a user
 
 ## Endpoint details
 

--- a/store/README.md
+++ b/store/README.md
@@ -278,6 +278,7 @@ __Weight__:
 ```
 
 #### Activities:
+Activities are synchronized with Google Calendar only on a limited timeframe. Currently, the timeframe is 7 days in the past and 7 days in the future, totally 14 days. If an event older than 7 days is modified in Google Calendar, it will not be updated in the CAMI Store.
 
 - full endpoint
 ```

--- a/store/README.md
+++ b/store/README.md
@@ -279,7 +279,7 @@ __Weight__:
 
 #### Activities:
 
-- full endpoint:
+- full endpoint
 ```
 http://cami.vitaminsoftware.com:8008/api/v1/activity/
 
@@ -335,7 +335,7 @@ http://cami.vitaminsoftware.com:8008/api/v1/activity/
 }
 ```
 
-- last activities endpoint:
+- last activities endpoint
 
 Currently, this retrieves the activities from 7 days in the past and 7 days in the future from the current time(14 days totally), for ALL the users. There is information only for one hardcoded user, though. This will have to be modified to accept a user parameter, in order to be able to retrieve information only for one user.
 

--- a/store/README.md
+++ b/store/README.md
@@ -276,3 +276,105 @@ __Weight__:
     }
 }
 ```
+
+### Activities:
+
+- full endpoint:
+```
+http://cami.vitaminsoftware.com:8008/api/v1/activity/
+
+{
+  "activities": [
+    {
+      "activity_type": "personal",
+      "calendar_id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "calendar_name": "Appointments",
+      "color": "{u'foreground': u'#000000', u'id': u'16', u'background': u'#4986e7'}",
+      "created": "1494544314",
+      "creator": "{u'email': u'proiect.cami@gmail.com'}",
+      "description": null,
+      "end": "1494603000",
+      "event_id": "pjm35ld41grfhrfh93472j1g24",
+      "html_link": "https://www.google.com/calendar/event?eid=cGptMzVsZDQxZ3JmaHJmaDkzNDcyajFnMjQgN2VoNnFuaXZpZDY0MzBkbDc5ZWk4OWsyNmdAZw",
+      "iCalUID": "pjm35ld41grfhrfh93472j1g24@google.com",
+      "id": 1,
+      "location": null,
+      "recurring_event_id": null,
+      "reminders": "{}",
+      "resource_uri": "/api/v1/activity/1/",
+      "start": "1494599400",
+      "status": "confirmed",
+      "title": "Tennis w/ Joel",
+      "updated": "1494552610",
+      "user": "/api/v1/user/2/"
+    },
+    {
+      "activity_type": "personal",
+      "calendar_id": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
+      "calendar_name": "Appointments",
+      "color": "{u'foreground': u'#000000', u'id': u'16', u'background': u'#4986e7'}",
+      "created": "1494556425",
+      "creator": "{u'email': u'proiect.cami@gmail.com'}",
+      "description": null,
+      "end": "1494689400",
+      "event_id": "nd044tjlq84a3cl0hpcgu4ck6g",
+      "html_link": "https://www.google.com/calendar/event?eid=bmQwNDR0amxxODRhM2NsMGhwY2d1NGNrNmcgN2VoNnFuaXZpZDY0MzBkbDc5ZWk4OWsyNmdAZw",
+      "iCalUID": "nd044tjlq84a3cl0hpcgu4ck6g@google.com",
+      "id": 2,
+      "location": null,
+      "recurring_event_id": null,
+      "reminders": "{}",
+      "resource_uri": "/api/v1/activity/2/",
+      "start": "1494685800",
+      "status": "confirmed",
+      "title": "Footbal Game",
+      "updated": "1494556425",
+      "user": "/api/v1/user/2/"
+    }
+  ]
+}
+```
+
+- last activities endpoint:
+Currently, this retrieves the activities from 7 days in the past and 7 days in the future from the current time(14 days totally), for ALL the users. There is information only for one hardcoded user, though. This will have to be modified to accept a user parameter, in order to be able to retrieve information only for one user.
+
+This is how it looks like:
+```
+http://cami.vitaminsoftware.com:8008/api/v1/activity/last_activities
+
+[
+  {
+    "activity_type": "medication",
+    "calendar_id": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
+    "calendar_name": "Medication",
+    "color": {
+      "background": "#fa573c",
+      "foreground": "#000000",
+      "id": "4"
+    },
+    "created": 1494413636,
+    "creator": {
+      "email": "proiect.cami@gmail.com"
+    },
+    "description": null,
+    "end": 1494504000,
+    "event_id": "h5bk4mchboa9od1uroe93nthi8_20170511T110000Z",
+    "html_link": "https://www.google.com/calendar/event?eid=aDViazRtY2hib2E5b2QxdXJvZTkzbnRoaThfMjAxNzA1MTFUMTEwMDAwWiB1czh2NWo2dHRwODg1NTQycTlvMmFsanJob0Bn",
+    "iCalUID": "h5bk4mchboa9od1uroe93nthi8@google.com",
+    "id": 6,
+    "location": null,
+    "recurring_event_id": "h5bk4mchboa9od1uroe93nthi8",
+    "reminders": {},
+    "start": 1494500400,
+    "status": "confirmed",
+    "title": "Analgezics",
+    "updated": 1494413636,
+    "user_id": 2
+  }
+]
+```
+
+- endpoint for manual synchronization of the events from GCal:
+A simple GET request from the browser address bar or CURL will trigger the syncronization.
+
+`http://cami.vitaminsoftware.com:8008/sync_activities/`


### PR DESCRIPTION
## Why
Following the progress made in #210, #211 & #212, we now have a working CAMI system integration with the Google Calendar API, and an endpoint used to fetch the latest events.

In order to ease future development to the CAMI backend and help out the client applications that will make use of it, we need to document this integration.

## What
* [x] the Activities endpoint documentation is added to the repository

## Notes
