### PR TITLE
Add API calls response logging and error checking in the Google Calendar container

### DIFF
--- a/google_calendar/activities.py
+++ b/google_calendar/activities.py
@@ -104,7 +104,7 @@ def process_events(user, calendar, events, date_from, date_to):
         db_events_hash[event_id] = {
             'id': db_event['id'],
             'updated': db_event['updated'],
-            'color': eval(db_event['color'])
+            'color': db_event['color']
         }
 
     # Process the events

--- a/google_calendar/google_calendar_backend.py
+++ b/google_calendar/google_calendar_backend.py
@@ -46,7 +46,7 @@ def get_credentials():
         flags = tools.argparser.parse_args(args=[])
         credentials = tools.run_flow(flow, store, flags)
 
-        logger.info('Storing GCal acccess credentials to ' + credential_path)
+        logger.info('[google_calendar_backend] Storing GCal acccess credentials to ' + credential_path)
 
     return credentials
 

--- a/google_calendar/store_utils.py
+++ b/google_calendar/store_utils.py
@@ -1,8 +1,6 @@
 import logging
 import requests
 
-from collections import namedtuple
-
 # Local imports
 import settings
 
@@ -13,7 +11,17 @@ logger = logging.getLogger("google_calendar.store_utils")
 def activity_get(**kwargs):
     endpoint = settings.STORE_ENDPOINT_URI + "/api/v1/activity/"
     r = requests.get(endpoint, params=dict(kwargs))
-    return r.json()['activities']
+
+    json_response = r.json()
+    if 'activities' in json_response:
+        return json_response['activities']
+
+    logger.debug(
+        "[google_calendar_store_utils] " +
+        "There was a problem fetching activities from Store. " +
+        "Arguments: %s. Response: %s" % (kwargs, r.text)
+    )
+    return False
 
 def activity_save(**kwargs):
     endpoint = settings.STORE_ENDPOINT_URI + "/api/v1/activity/"
@@ -31,14 +39,36 @@ def activity_save(**kwargs):
         json=data
     )
 
-    return r.status_code == 204
+    if r.status_code == 200:
+        return True
+
+    logger.debug(
+        "[google_calendar_store_utils] " +
+        "There was a problem saving the activity to Store. " +
+        "Arguments: %d. Response: %s" % (r.status_code, r.text)
+    )
+    return False
 
 def activity_delete(**kwargs):
     endpoint = settings.STORE_ENDPOINT_URI + "/api/v1/activity/"
     r = requests.delete(endpoint, params=dict(kwargs))
-    return r.status_code == 204
+
+    if r.status_code == 204:
+        return True
+
+    logger.debug(
+        "[google_calendar_store_utils] " +
+        "There was a problem deleting the activities from Store. " +
+        "Arguments: %s. Response: %s" % (kwargs, r.text)
+    )
+    return False
 
 def user_get(id):
     endpoint = settings.STORE_ENDPOINT_URI + "/api/v1/user/" + str(id)
     r = requests.get(endpoint)
-    return r.json()
+
+    json_response = r.json()
+    if json_response:
+        return json_response
+
+    return False

--- a/store/store/api/resources.py
+++ b/store/store/api/resources.py
@@ -113,7 +113,6 @@ class MeasurementResource(ModelResource):
     def dehydrate_timestamp(self, bundle):
         return int(bundle.data['timestamp'])
 
-
     def dehydrate(self, bundle):
         '''
         By default the value_info JSONField is retrieved from the DB as a unicode string.
@@ -181,6 +180,18 @@ class ActivityResource(ModelResource):
         return [
             url(r"^(?P<resource_name>%s)/last_activities%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_last_activities'), name="api_last_activities"),
         ]
+
+    def dehydrate(self, bundle):
+        bundle.data['start'] = int(bundle.data['start'])
+        bundle.data['end'] = int(bundle.data['end'])
+        bundle.data['created'] = int(bundle.data['created'])
+        bundle.data['updated'] = int(bundle.data['updated'])
+
+        bundle.data['color'] = ast.literal_eval(bundle.data['color'])
+        bundle.data['reminders'] = ast.literal_eval(bundle.data['reminders'])
+        bundle.data['creator'] = ast.literal_eval(bundle.data['creator'])
+
+        return bundle
 
     def get_last_activities(self, request, **kwargs):
         self.method_check(request, allowed=['get'])


### PR DESCRIPTION
## Why
Now that we've split the Google Calendar functionality from the Store container, we need to have proper logging for the new container, in order to be sure that it works as intended, or easily debug it in case it does not work as intended.

## What
- [x] Update logging with Store API calls responses
- [x] Check for errors in the Store API calls responses

## Notes
Follow-up of #231.