### PR TITLE
Update paths in Dockerfiles

### DIFF
--- a/docker/Dockerfile-frontend
+++ b/docker/Dockerfile-frontend
@@ -4,16 +4,16 @@ FROM williamyeh/ansible:ubuntu16.04
 # Add playbooks to the Docker image. This requires that the build context is the
 # project root folder. Run build like:
 # `docker build -f docker/cami-store/Dockerfile .`
-COPY . /cami-project
+COPY ../ /cami-project
 WORKDIR /cami-project
 
 # Run Ansible to configure the Docker image
-RUN ansible-playbook ansible/frontend.yml -c local
+RUN ansible-playbook ../ansible/frontend.yml -c local
 
-COPY docker/cami-frontend/docker-entrypoint.sh /usr/local/bin/
-COPY docker/cami-frontend/docker-migration-entrypoint.sh /usr/local/bin/
-COPY docker/cami-frontend/docker-message-worker-entrypoint.sh /usr/local/bin/
-COPY docker/cami-frontend/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
+COPY ../docker/cami-frontend/docker-entrypoint.sh /usr/local/bin/
+COPY ../docker/cami-frontend/docker-migration-entrypoint.sh /usr/local/bin/
+COPY ../docker/cami-frontend/docker-message-worker-entrypoint.sh /usr/local/bin/
+COPY ../docker/cami-frontend/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
 
 RUN adduser --disabled-password --gecos '' frontend
 RUN chown frontend /cami-project

--- a/docker/Dockerfile-google-calendar
+++ b/docker/Dockerfile-google-calendar
@@ -4,16 +4,16 @@ FROM williamyeh/ansible:ubuntu16.04
 # Add playbooks to the Docker image. This requires that the build context is the
 # project root folder. Run build like:
 # `docker build -f docker/cami-store/Dockerfile .`
-COPY . /cami-project
+COPY ../ /cami-project
 WORKDIR /cami-project
 
 # Run Ansible to configure the Docker image
-RUN ansible-playbook ansible/google_calendar.yml -c local
+RUN ansible-playbook ../ansible/google_calendar.yml -c local
 
-COPY docker/google_calendar/docker-message-worker-entrypoint.sh /usr/local/bin/
-COPY docker/google_calendar/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
-COPY docker/google_calendar/docker-task-scheduler-entrypoint.sh /usr/local/bin/
-COPY docker/google_calendar/docker-task-scheduler-entrypoint-dev.sh /usr/local/bin/
+COPY ../docker/google_calendar/docker-message-worker-entrypoint.sh /usr/local/bin/
+COPY ../docker/google_calendar/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
+COPY ../docker/google_calendar/docker-task-scheduler-entrypoint.sh /usr/local/bin/
+COPY ../docker/google_calendar/docker-task-scheduler-entrypoint-dev.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/docker-message-worker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-message-worker-entrypoint-dev.sh

--- a/docker/Dockerfile-linkwatch
+++ b/docker/Dockerfile-linkwatch
@@ -4,14 +4,14 @@ FROM williamyeh/ansible:ubuntu16.04
 # Add playbooks to the Docker image. This requires that the build context is the
 # project root folder. Run build like:
 # `docker build -f docker/cami-store/Dockerfile .`
-COPY . /cami-project
+COPY ../ /cami-project
 WORKDIR /cami-project
 
 # Run Ansible to configure the Docker image
-RUN ansible-playbook ansible/linkwatch.yml -c local
+RUN ansible-playbook ../ansible/linkwatch.yml -c local
 
-COPY docker/linkwatch/docker-message-worker-entrypoint.sh /usr/local/bin/
-COPY docker/linkwatch/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
+COPY ../docker/linkwatch/docker-message-worker-entrypoint.sh /usr/local/bin/
+COPY ../docker/linkwatch/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
 
 RUN touch /cami-project/linkwatch/debug.log
 RUN chmod a+rw /cami-project/linkwatch/debug.log

--- a/docker/Dockerfile-medical-compliance
+++ b/docker/Dockerfile-medical-compliance
@@ -4,18 +4,18 @@ FROM williamyeh/ansible:ubuntu16.04
 # Add playbooks to the Docker image. This requires that the build context is the
 # project root folder. Run build like:
 # `docker build -f docker/cami-store/Dockerfile .`
-COPY . /cami-project
+COPY ../ /cami-project
 WORKDIR /cami-project
 
 # Run Ansible to configure the Docker image
-RUN ansible-playbook ansible/medical_compliance.yml -c local
+RUN ansible-playbook ../ansible/medical_compliance.yml -c local
 
-COPY docker/cami-medical-compliance/docker-entrypoint.sh /usr/local/bin/
-COPY docker/cami-medical-compliance/docker-migration-entrypoint.sh /usr/local/bin/
-COPY docker/cami-medical-compliance/docker-message-worker-entrypoint.sh /usr/local/bin/
-COPY docker/cami-medical-compliance/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
-COPY docker/cami-medical-compliance/docker-task-scheduler-entrypoint.sh /usr/local/bin/
-COPY docker/cami-medical-compliance/docker-task-scheduler-entrypoint-dev.sh /usr/local/bin/
+COPY ../docker/cami-medical-compliance/docker-entrypoint.sh /usr/local/bin/
+COPY ../docker/cami-medical-compliance/docker-migration-entrypoint.sh /usr/local/bin/
+COPY ../docker/cami-medical-compliance/docker-message-worker-entrypoint.sh /usr/local/bin/
+COPY ../docker/cami-medical-compliance/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
+COPY ../docker/cami-medical-compliance/docker-task-scheduler-entrypoint.sh /usr/local/bin/
+COPY ../docker/cami-medical-compliance/docker-task-scheduler-entrypoint-dev.sh /usr/local/bin/
 
 RUN touch /cami-project/medical_compliance/debug.log
 RUN chmod a+rw /cami-project/medical_compliance/debug.log

--- a/docker/Dockerfile-opentele
+++ b/docker/Dockerfile-opentele
@@ -4,14 +4,14 @@ FROM williamyeh/ansible:ubuntu16.04
 # Add playbooks to the Docker image. This requires that the build context is the
 # project root folder. Run build like:
 # `docker build -f docker/cami-store/Dockerfile .`
-COPY . /cami-project
+COPY ../ /cami-project
 WORKDIR /cami-project
 
 # Run Ansible to configure the Docker image
-RUN ansible-playbook ansible/opentele.yml -c local
+RUN ansible-playbook ../ansible/opentele.yml -c local
 
-COPY docker/opentele/docker-message-worker-entrypoint.sh /usr/local/bin/
-COPY docker/opentele/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
+COPY ../docker/opentele/docker-message-worker-entrypoint.sh /usr/local/bin/
+COPY ../docker/opentele/docker-message-worker-entrypoint-dev.sh /usr/local/bin/
 
 RUN touch /cami-project/opentele/debug.log
 RUN chmod a+rw /cami-project/opentele/debug.log

--- a/docker/Dockerfile-store
+++ b/docker/Dockerfile-store
@@ -4,14 +4,14 @@ FROM williamyeh/ansible:ubuntu16.04
 # Add playbooks to the Docker image. This requires that the build context is the
 # project root folder.
 
-COPY . /cami-project
+COPY ../ /cami-project
 WORKDIR /cami-project
 
 # Run Ansible to configure the Docker image
-RUN ansible-playbook ansible/store.yml -c local
+RUN ansible-playbook ../ansible/store.yml -c local
 
-COPY docker/cami-store/docker-entrypoint.sh /usr/local/bin/
-COPY docker/cami-store/docker-migration-entrypoint.sh /usr/local/bin/
+COPY ../docker/cami-store/docker-entrypoint.sh /usr/local/bin/
+COPY ../docker/cami-store/docker-migration-entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-migration-entrypoint.sh


### PR DESCRIPTION
## Why
The changes from #239 left the Dockerfiles not functional, because of the paths are relative. We need to also update the paths from Dockerfiles in order to make everything functional again.

## What
- [x] Update the paths to reflect the new directory tree

## Notes
