### PR TITLE
Update the medical-compliance container to reflect the last changes in FRONTEND

### DIFF
--- a/frontend/frontend/tasks.py
+++ b/frontend/frontend/tasks.py
@@ -17,8 +17,8 @@ from celery.utils.log import get_task_logger
 from django.conf import settings
 
 # Local imports
-import frontend.store_utils
-import frontend.push_notifications.notifications
+from frontend import store_utils
+from frontend.push_notifications import notifications
 
 
 logger = get_task_logger('frontend.tasks')
@@ -34,5 +34,6 @@ app.conf.update(
 @app.task(name='frontend.send_notification')
 def send_notification(user_id, message):
     logger.debug("[frontend] Send notification request: %s" % (locals()))
-    devices = store_utils.pushnotificationdevice_get(user="/api/v1/user/" + str(user_id))
-    notifications.send_message(devices, message, sound="default")
+    devices = store_utils.pushnotificationdevice_get(user=int(user_id))
+    if devices:
+    	notifications.send_message(devices, message, sound="default")

--- a/medical_compliance/medical_compliance/api/analyzers/notifications_adapter.py
+++ b/medical_compliance/medical_compliance/api/analyzers/notifications_adapter.py
@@ -1,6 +1,8 @@
 import celery
 from celery import Celery
 
+from medical_compliance.api import store_utils
+
 class NotificationsAdapter():
     __celery_notification_task = 'frontend.send_notification'
     __celery_queue = 'frontend_notifications'
@@ -21,6 +23,17 @@ class NotificationsAdapter():
             queue=self.__celery_queue
         )
 
+        store_utils.insert_journal_entry(
+            user="/api/v1/user/%d/" % 3,
+            type=notification_type,
+            severity=severity,
+            timestamp=timestamp,
+            message=message,
+            description=description,
+            # This is dummy, will be removed anyway when refactoring medical_compliance
+            measurement="/api/v1/measurement/%d/" % 1
+        )
+
     def send_elderly_notification(self, user_id, notification_type, severity, message, description, timestamp = None):
         celery_app = self.__get_celery_app()
         celery_app.send_task(
@@ -30,4 +43,15 @@ class NotificationsAdapter():
                 message
             ),
             queue=self.__celery_queue
+        )
+
+        store_utils.insert_journal_entry(
+            user="/api/v1/user/%d/" % 2,
+            type=notification_type,
+            severity=severity,
+            timestamp=timestamp,
+            message=message,
+            description=description,
+            # This is dummy, will be removed anyway when refactoring medical_compliance
+            measurement="/api/v1/measurement/%d/" % 1
         )

--- a/medical_compliance/medical_compliance/api/analyzers/notifications_adapter.py
+++ b/medical_compliance/medical_compliance/api/analyzers/notifications_adapter.py
@@ -12,8 +12,22 @@ class NotificationsAdapter():
 
     def send_caregiver_notification(self, user_id, notification_type, severity, message, description, timestamp = None):
         celery_app = self.__get_celery_app()
-        celery_app.send_task(self.__celery_notification_task, (user_id, 'caregiver', notification_type, severity, message, description, timestamp), queue=self.__celery_queue)
+        celery_app.send_task(
+            self.__celery_notification_task,
+            (
+                3,
+                message
+            ),
+            queue=self.__celery_queue
+        )
 
     def send_elderly_notification(self, user_id, notification_type, severity, message, description, timestamp = None):
         celery_app = self.__get_celery_app()
-        celery_app.send_task(self.__celery_notification_task, (user_id, 'elderly', notification_type, severity, message, description, timestamp), queue=self.__celery_queue)
+        celery_app.send_task(
+            self.__celery_notification_task,
+            (
+                2,
+                message
+            ),
+            queue=self.__celery_queue
+        )

--- a/medical_compliance/medical_compliance/api/store_utils.py
+++ b/medical_compliance/medical_compliance/api/store_utils.py
@@ -126,3 +126,25 @@ def insert_measurement(store_endpoint_host_uri, user_id, device_id,
                      % (user_id, device_id, measurement_type, measurement_unit, str(timestamp), str(value_info)))
         r.raise_for_status()
 
+def insert_journal_entry(**kwargs):
+    endpoint = STORE_ENDPOINT_URI + "/api/v1/journal_entries/"
+
+    method = 'POST'
+    data = dict(kwargs)
+
+    r = requests.request(
+        method,
+        endpoint,
+        json=data
+    )
+
+    if r.status_code in [200, 201]:
+        return r.json()
+
+    logger.debug(
+        "[medical_compliance.store_utils] " +
+        "Failed inserting a new Journal Entry. " +
+        "Arguments: %s. Response: %s" % (kwargs, r.text)
+    )
+    return False
+

--- a/store/store/api/resources.py
+++ b/store/store/api/resources.py
@@ -73,7 +73,7 @@ class DeviceUsageResource(ModelResource):
 
         return bundle
 
-    def build_filters(self, filters = None):
+    def build_filters(self, filters=None, ignore_bad_filters=True):
         if filters is None:
             filters = {}
 
@@ -126,7 +126,7 @@ class MeasurementResource(ModelResource):
 
         return bundle
 
-    def build_filters(self, filters = None):
+    def build_filters(self, filters=None, ignore_bad_filters=True):
         '''
         The double underscores are for the JSONFields value_info are interpreted
         by Tastypie as relational filters.
@@ -271,6 +271,7 @@ class JournalEntryResource(ModelResource):
         paginator_class = Paginator
 
         filtering = {
+            "user": ALL_WITH_RELATIONS,
             "timestamp": ('gt'),
             "recipient_type": ('exact')
         }

--- a/store/store/api/resources.py
+++ b/store/store/api/resources.py
@@ -261,6 +261,7 @@ class ActivityResource(ModelResource):
 
 class JournalEntryResource(ModelResource):
     user = fields.ForeignKey(UserResource, 'user')
+    measurement = fields.ForeignKey(MeasurementResource, 'measurement')
     
     class Meta:
         authentication = Authentication()


### PR DESCRIPTION
## Why
After the changes from #256 and #257, the medical-compliance will fail to both send push notifications and create journal entries, as the inferface and the functionality of the `frontend` container were changed.

## What
- [x] Update the `medical-compliance` container
  - [x] to use the new task for sending notifications
  - [x] to send the 'old' notifications - now `JournalEntry` in `store` - to the `store` instead of `frontend`

## Notes
Part of the plan from #255.