### PR TITLE
Handle exceptions in push notifications sending methods from FRONTEND container

### DIFF
--- a/frontend/frontend/push_notifications/notifications.py
+++ b/frontend/frontend/push_notifications/notifications.py
@@ -10,16 +10,28 @@ logger = logging.getLogger("frontend.push_notifications.notifications")
 def send_message(devices, message, **kwargs):
     for device in devices:
         if device['type'] == "APNS":
-            apns.apns_send_message(
-                device['registration_id'],
-                message,
-                None,
-                None,
-                **kwargs
-            )
-            logger.debug("[frontend] Sent notification to device (%s): \"%s\"" % (
-                str(device),
-                message
-            ))
+            try:
+                apns.apns_send_message(
+                    device['registration_id'],
+                    message,
+                    None,
+                    None,
+                    **kwargs
+                )
+
+                logger.debug(
+                    "[frontend] Sent notification to device (%s): \"%s\"",
+                    str(device),
+                    message
+                )
+            except apns.APNSError as e:
+                logger.debug(
+                    "[frontend] Failed sending notification to device (%s): %s",
+                    str(device),
+                    repr(e)
+                )
         else:
-            logger.debug("[frontend] Failed sending notification to device (%s)." % str(device))
+            logger.debug(
+                    "[frontend] Failed sending notification to device (%s): push notification provider currently not supported",
+                    str(device)
+                )


### PR DESCRIPTION
## Why
Handling exceptions is very important to ensure the good functioning of on application, as it can totally break if one exception is not properly caught.

This is what is actually happening now in the `frontend` container. There is one uncaught exception that breaks all the functionality.

## What
- [x] Treat exceptions thrown in the `send_message` function from `notifications` module of `frontend` container

## Notes
```
Traceback (most recent call last):
  File "frontend/worker.py", line 46, in <module>
    worker.run()
  File "/usr/local/lib/python2.7/dist-packages/kombu/mixins.py", line 177, in run
    for _ in self.consume(limit=None):  # pragma: no cover
  File "/usr/local/lib/python2.7/dist-packages/kombu/mixins.py", line 199, in consume
    conn.drain_events(timeout=safety_interval)
  File "/usr/local/lib/python2.7/dist-packages/kombu/connection.py", line 288, in drain_events
    return self.transport.drain_events(self.connection, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/pyamqp.py", line 95, in drain_events
    return connection.drain_events(**kwargs)
  File "/usr/local/lib/python2.7/dist-packages/amqp/connection.py", line 326, in drain_events
    return amqp_method(channel, args, content)
  File "/usr/local/lib/python2.7/dist-packages/amqp/channel.py", line 1909, in _basic_deliver
    fun(msg)
  File "/usr/local/lib/python2.7/dist-packages/kombu/messaging.py", line 598, in _receive_callback
    return on_m(message) if on_m else self.receive(decoded, message)
  File "/usr/local/lib/python2.7/dist-packages/kombu/messaging.py", line 564, in receive
    [callback(body, message) for callback in callbacks]
  File "frontend/worker.py", line 39, in on_message
    notifications.send_message(devices, payload['message'], sound="default")
  File "/cami-project/frontend/frontend/push_notifications/notifications.py", line 18, in send_message
    **kwargs
  File "/cami-project/frontend/frontend/push_notifications/apns.py", line 118, in apns_send_message
    raise APNSServerError(status=reason_for_exception_class(apns2_exception.__class__))
frontend.push_notifications.apns.APNSServerError: BadDeviceToken
```