### PR TITLE
Update the iOS app with the new endpoints

### DIFF
--- a/application/env.example.js
+++ b/application/env.example.js
@@ -6,11 +6,11 @@ module.exports = {
   AUTH0_CLIENT_ID: 'xqN8fSjHL6850gI2m8AUkk5GICgvTCUs',
   AUTH0_DOMAIN: 'vitamin.eu.auth0.com',
   POLL_INTERVAL_MILLIS: 5000,
-  NOTIFICATIONS_REST_API: 'http://cami.vitaminsoftware.com:8001/api/v1/notifications/',
+  NOTIFICATIONS_REST_API: 'http://cami.vitaminsoftware.com:8008/api/v1/journal_entries/',
   ACTIVITIES_LAST_EVENTS: 'http://cami.vitaminsoftware.com:8008/api/v1/activity/last_activities/',
   WEIGHT_MEASUREMENTS_LAST_VALUES: 'http://cami.vitaminsoftware.com:8000/api/v1/weight-measurements/last_values/',
   HEARTRATE_MEASUREMENTS_LAST_VALUES: 'http://cami.vitaminsoftware.com:8000/api/v1/heartrate-measurements/last_values/',
   STEPS_MEASUREMENTS_LAST_VALUES: 'http://cami.vitaminsoftware.com:8000/api/v1/steps-measurements/last_values/',
   NOTIFICATIONS_SUBSCRIPTION_API: 'http://cami.vitaminsoftware.com:8000/subscribe_notifications/',
-  MOBILE_NOTIFICATION_KEY_API: 'http://cami.vitaminsoftware.com:8001/api/v1/mobile-notification-key/'
+  MOBILE_NOTIFICATION_KEY_API: 'http://cami.vitaminsoftware.com:8001/api/v1/push-notification-subscribe/'
 };

--- a/application/index.ios.js
+++ b/application/index.ios.js
@@ -10,10 +10,6 @@ import {AppRegistry} from 'react-native';
 const Cami = React.createClass({
 
   render() {
-    // Start polling for notifications.
-    store.dispatch(HomepageStateActions.requestNotification());
-    store.dispatch(HomepageCaregiverStateActions.requestCaregiverData());
-
     return (
       <Provider store={store}>
         <AppViewContainer />

--- a/application/ios/Cami/Info.plist
+++ b/application/ios/Cami/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.4</string>
+	<string>1.2.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/application/src/modules/homepage-caregiver/HomepageState.js
+++ b/application/src/modules/homepage-caregiver/HomepageState.js
@@ -92,6 +92,8 @@ async function fetchPageData() {
     lastActivities: []
   };
 
+  console.log("[HomepageState] - fetching data for the [careviger] with id: " + user_id);
+
   return fetch(notificationsUrl)
     .then((response) => response.json())
     .then((notificationJson) => {
@@ -131,39 +133,41 @@ async function fetchPageData() {
 
       return fetch(activitiesApiUrl).then((response) => response.json())
         .then((activitiesJson) => {
-
           result.lastActivities = activitiesJson;
 
           return fetch(weightApiUrl).then((response) => response.json())
             .then((weightsJson) => {
-
               result.weight = weightsJson.weight;
 
               return fetch(heartRateApiUrl).then((response) => response.json())
                 .then((heartRateJson) => {
-
                   result.heart_rate = heartRateJson.heart_rate;
 
                   return fetch(stepsCountApiUrl).then((response) => response.json())
                     .then((stepsCountJson) => {
-
                       result.steps = stepsCountJson.steps;
+
+                      console.log('[HomepageState] - successfully fetched [caregiver] data');
 
                       return result;
 
                   }).catch((error) => {
+                    console.warning('[HomepageState] - encountered error while fetching [caregiver] step count: ' + error);
 
                     return result;
                   });
               }).catch((error) => {
+                console.warning('[HomepageState] - encountered error while fetching [caregiver] heart rate: ' + error);
 
                 return result;
               });
           }).catch((error) => {
+            console.warning('[HomepageState] - encountered error while fetching [caregiver] weight: ' + error);
 
             return result;
           });
       }).catch((error) => {
+        console.warning('[HomepageState] - encountered error while fetching [caregiver] activities: ' + error);
 
         return result;
       });

--- a/application/src/modules/homepage-caregiver/HomepageState.js
+++ b/application/src/modules/homepage-caregiver/HomepageState.js
@@ -1,6 +1,7 @@
 import Promise from 'bluebird';
 import {fromJS, Map} from 'immutable';
 import {loop, Effects} from 'redux-loop';
+import store from '../../redux/store';
 import icons from 'Cami/src/icons-fa';
 
 import * as env from '../../../env';
@@ -41,6 +42,7 @@ const initialState = Map({
   })
 });
 
+
 // Actions
 const HIDE_ACTIONABILITY = 'HomepageState/HIDE_ACTIONABILITY';
 const CAREGIVER_DATA_RESPONSE = 'HomepageState/CAREGIVER_DATA_RESPONSE';
@@ -60,8 +62,12 @@ export async function requestCaregiverData() {
 }
 
 async function fetchPageData() {
-  var notificationsUrl = env.NOTIFICATIONS_REST_API + "?recipient_type=caregiver&limit=10&offset=0";
+  // getting the user id from state after auth0 signin
+  var user_id = store.getState().get('auth').get('currentUser').get('userMetadata').get('user_id');
+  var notificationsUrl = env.NOTIFICATIONS_REST_API + "?user=" + user_id;
+  // override caching issues
   notificationsUrl += '&r=' + Math.floor(Math.random() * 10000);
+
   var result = {
     hasNotification: false,
     weight: {

--- a/application/src/modules/journal/JournalState.js
+++ b/application/src/modules/journal/JournalState.js
@@ -26,7 +26,7 @@ export async function requestJournalData() {
   };
 }
 async function fetchPageData() {
-  var notificationsUrl = env.NOTIFICATIONS_REST_API + "?recipient_type=caregiver&limit=30&offset=0";
+  var notificationsUrl = env.NOTIFICATIONS_REST_API + "?user=3";
   notificationsUrl += '&r=' + Math.floor(Math.random() * 10000);
 
   return fetch(notificationsUrl)

--- a/application/src/modules/status/components/StatusEntry.js
+++ b/application/src/modules/status/components/StatusEntry.js
@@ -118,9 +118,6 @@ const StatusEntry = React.createClass({
       dataSet.circleColors.push(this.formatStatus(item.get('status')));
     });
 
-    console.log('DATA SET -------------');
-    console.log(dataSet);
-
     // for the majority of the status widgets we get the most recent value
     var lastValue = this.props.data.size > 0 ? this.props.data.get(this.props.data.size - 1).get('value') : 0;
 


### PR DESCRIPTION
## Why
After the changes from #256, #257 and #258, the iOS application will have to fetch the journal entries from another endpoint. This change reflects the specs from #221: the `store` container will be the central API for inserting and pushing data in DB.

## What
- [x] Add another field to the Auth0 accounts for the `user_id`
  - [x] Set it to `2` for the `elder` account
  - [x] Set it to `3` for the `caregiver` account
- [x] Change the endpoint for subscribing to push notifications
  - [x] The new endpoint is: `http://cami.vitaminsoftware.com:8001/api/v1/push-notification-subscribe/`
  - [x] Request method: `POST`
  - [x] The payload that needs to be sent is:
```
{
    "user_id": <the id of the user currently logged in>,
    "registration_id": <the APNS device token>,
    "service_type": "APNS"
}
```
- [x] Change the endpoint for fetching `Journal Entries`:
  - [x] The new endpoint is: `http://cami.vitaminsoftware.com:8008/api/v1/journal_entries/?user=<user_id>`
  - [x] Request method: `GET`

## Notes
Part of the plan from #255.