### PR TITLE
Send the measurements fetched in medical_compliance also to the new measurements queue

### DIFF
--- a/insertion/insertion/views.py
+++ b/insertion/insertion/views.py
@@ -18,7 +18,8 @@ def insert_measurement(request):
     try:
         content = json.loads(request.body)
         if 'measurement_type' in content:
-            # get a connection to RabbitMQ broker, create a channel and create a producer for pushing the message to the health_measurements exchange
+            # get a connection to RabbitMQ broker, create a channel and create a
+            # producer for pushing the message to the measurements exchange
             with Connection(settings.BROKER_URL) as conn:
                 channel = conn.channel()
 


### PR DESCRIPTION
## Why
We don't want the refactoring of the `medical_compliance` container to be a blocker for the project. We want to make progress while also continuing the refactoring of the system. This will give us a temporary solution of having all the measurements available in the new system-wide queues that we recently created, so the other containers being developed by our partners could use them.

## What
- [x] Send the measurements fetched from **Google Fit** also to the system-wide queues
- [x] Send the measurements fetched from **Withings** also to the system-wide queues

## Notes
