### PR TITLE
Modify the Google Calendar container to support sending reminders

### DIFF
--- a/google_calendar/activities.py
+++ b/google_calendar/activities.py
@@ -108,13 +108,24 @@ def process_events(user, calendar, events, date_from, date_to):
         }
 
     # Process the events
-    for event in events:
+    for event in events['items']:
         activity_data = compose_activity_data(
             event,
             calendar,
             calendar_colors,
             user
         )
+
+        if event['reminders']['useDefault']:
+            activity_data['reminders'] = process_event_reminders(
+                activity_data['start'],
+                events['defaultReminders']
+            )
+        elif 'overrides' in event['reminders']:
+            activity_data['reminders'] = process_event_reminders(
+                activity_data['start'],
+                event['reminders']['overrides']
+            )
 
         if event['id'] in db_events_hash:
             db_event = db_events_hash[event['id']]
@@ -205,3 +216,10 @@ def timestamp_from_event_date(date):
         dateutil.parser.parse(date).utctimetuple()
     )
 
+def process_event_reminders(start_timestamp, raw_reminders):
+    reminders = []
+
+    for r in raw_reminders:
+        reminders.append(start_timestamp - r['minutes'] * 60)
+
+    return reminders

--- a/google_calendar/activities.py
+++ b/google_calendar/activities.py
@@ -178,8 +178,6 @@ def compose_activity_data(event, calendar, calendar_colors, user):
         'title': event['summary'],
         'calendar_id': calendar['id'],
         'calendar_name': calendar['summary'],
-        'start': timestamp_from_event_date(event['start']['dateTime']),
-        'end': timestamp_from_event_date(event['end']['dateTime']),
         'created': timestamp_from_event_date(event['created']),
         'updated': timestamp_from_event_date(event['updated']),
         'activity_type': calendar['activity_type'],
@@ -187,6 +185,16 @@ def compose_activity_data(event, calendar, calendar_colors, user):
         'creator': event['creator'],
         'iCalUID': event['iCalUID']
     }
+
+    if 'dateTime' in event['start']:
+        activity_data['start'] = timestamp_from_event_date(event['start']['dateTime'])
+    else:
+        activity_data['start'] = timestamp_from_event_date(event['start']['date'])
+
+    if 'dateTime' in event['end']:
+        activity_data['end'] = timestamp_from_event_date(event['end']['dateTime'])
+    else:
+        activity_data['end'] = timestamp_from_event_date(event['end']['date'])
 
     if 'description' in event:
         activity_data['description'] = event['description']

--- a/google_calendar/activities.py
+++ b/google_calendar/activities.py
@@ -228,6 +228,6 @@ def process_event_reminders(start_timestamp, raw_reminders):
     reminders = []
 
     for r in raw_reminders:
-        reminders.append(start_timestamp - r['minutes'] * 60)
+        reminders.append(str(start_timestamp - r['minutes'] * 60))
 
     return reminders

--- a/google_calendar/activities.py
+++ b/google_calendar/activities.py
@@ -20,8 +20,7 @@ def sync_for_user(user):
     calendars = {
         "personal": "7eh6qnivid6430dl79ei89k26g@group.calendar.google.com",
         "exercise": "8puar0sc4e7efns5r849rn0lus@group.calendar.google.com",
-        "medication": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com",
-        "measurement": ""
+        "medication": "us8v5j6ttp885542q9o2aljrho@group.calendar.google.com"
     }
 
     logger.debug("[google_calendar] Getting the Google Calendar service... ")

--- a/google_calendar/google_calendar_backend.py
+++ b/google_calendar/google_calendar_backend.py
@@ -105,7 +105,7 @@ def get_calendar(calendar_service, calendar_id):
         raise e
 
 def consume_event_results(calendar_service, api_req):
-    event_results = []
+    event_results = None
 
     while True:
         try:
@@ -114,12 +114,13 @@ def consume_event_results(calendar_service, api_req):
             logger.exception("[google_calendar_backend] Cannot consume all results from api_req %s." % (api_req))
             break
 
-        if current_res['items']:
-            event_results.extend(current_res['items'])
+        if event_results is None:
+            event_results = current_res
+        elif current_res['items']:
+            event_results['items'].extend(current_res['items'])
 
         api_req = calendar_service.events().list_next(api_req, current_res)
         if not api_req:
             break
 
     return event_results
-

--- a/google_calendar/settings.py
+++ b/google_calendar/settings.py
@@ -70,6 +70,10 @@ CELERYBEAT_SCHEDULE = {
         'task': 'google_calendar.sync_activities',
         'schedule': timedelta(minutes=5),
     },
+    'process_reminders': {
+        'task': 'google_calendar.process_reminders',
+        'schedule': timedelta(minutes=1),
+    },
 }
 
 ## CELERY settings

--- a/google_calendar/store_utils.py
+++ b/google_calendar/store_utils.py
@@ -17,7 +17,7 @@ def activity_get(**kwargs):
         return json_response['activities']
 
     logger.debug(
-        "[google_calendar_store_utils] " +
+        "[google_calendar.store_utils] " +
         "There was a problem fetching activities from Store. " +
         "Arguments: %s. Response: %s" % (kwargs, r.text)
     )
@@ -43,7 +43,7 @@ def activity_save(**kwargs):
         return True
 
     logger.debug(
-        "[google_calendar_store_utils] " +
+        "[google_calendar.store_utils] " +
         "There was a problem saving the activity to Store. " +
         "Arguments: %s. Response: %s" % (kwargs, r.text)
     )
@@ -57,7 +57,7 @@ def activity_delete(**kwargs):
         return True
 
     logger.debug(
-        "[google_calendar_store_utils] " +
+        "[google_calendar.store_utils] " +
         "There was a problem deleting the activities from Store. " +
         "Arguments: %s. Response: %s" % (kwargs, r.text)
     )
@@ -89,7 +89,7 @@ def insert_journal_entry(**kwargs):
         return r.json()
 
     logger.debug(
-        "[medical_compliance.store_utils] " +
+        "[google_calendar.store_utils] " +
         "Failed inserting a new Journal Entry. " +
         "Arguments: %s. Response: %s" % (kwargs, r.text)
     )

--- a/google_calendar/store_utils.py
+++ b/google_calendar/store_utils.py
@@ -72,3 +72,25 @@ def user_get(id):
         return json_response
 
     return False
+
+def insert_journal_entry(**kwargs):
+    endpoint = settings.STORE_ENDPOINT_URI + "/api/v1/journal_entries/"
+
+    method = 'POST'
+    data = dict(kwargs)
+
+    r = requests.request(
+        method,
+        endpoint,
+        json=data
+    )
+
+    if r.status_code in [200, 201]:
+        return r.json()
+
+    logger.debug(
+        "[medical_compliance.store_utils] " +
+        "Failed inserting a new Journal Entry. " +
+        "Arguments: %s. Response: %s" % (kwargs, r.text)
+    )
+    return False

--- a/google_calendar/tasks.py
+++ b/google_calendar/tasks.py
@@ -1,4 +1,6 @@
+import time
 import logging
+import datetime
 
 from kombu import Queue, Exchange
 from celery import Celery
@@ -26,3 +28,19 @@ def sync_activities():
 @app.task(name='google_calendar.sync_activities_for_user')
 def sync_activities_for_user(user):
     activities.sync_for_user(user)
+
+@app.task(name='google_calendar.process_reminders')
+def process_reminders():
+    # Get current minute in UTC timestamp
+    time_now = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M")
+    time_now = time.mktime(time.strptime(time_now, "%a, %d %b %Y %H:%M"))
+    
+    # Get all the activities that should be reminded in the current minute
+    # and send reminders for each one of them
+    activities = store_utils.activity_get(reminders__contains=int(time_now))
+    for activity in activities:
+        app.send_task('google_calendar.send_reminder', [activity])
+
+@app.task(name='google_calendar.send_reminder')
+def send_reminder(activity):
+    pass

--- a/store/store/api/resources.py
+++ b/store/store/api/resources.py
@@ -217,6 +217,7 @@ class ActivityResource(ModelResource):
             "end": ALL,
             "activity_type": ALL,
             "calendar_id": ALL,
+            "reminders": ALL,
         }
 
     def prepend_urls(self):

--- a/store/store/models.py
+++ b/store/store/models.py
@@ -191,8 +191,7 @@ class Activity(models.Model):
     ACTIVITY_TYPE = (
         ("personal", "personal"),
         ("exercise", "exercise"),
-        ("medication", "medication"),
-        ("measurement", "measurement")
+        ("medication", "medication")
     )
 
     event_id = models.CharField(max_length=64)
@@ -235,7 +234,9 @@ class JournalEntry(models.Model):
         ('weight', 'weight'),
         ('heart', 'heart'),
         ('sleep', 'sleep'),
-        ('activity', 'activity')
+        ('exercise', 'exercise'),
+        ('medication', 'medication'),
+        ('appointment', 'appointment')
     )
 
     SEVERITIES = (


### PR DESCRIPTION
## Why
One of the key points for the September milestone is the support for Activity Reminders. We will use the events generated by the reminders in various ways in the Decision Support System that is to be implemented.

## What
- [x] A task that will be called every minute will be created
- [x] The task will check for the activities that should be reminded at that moment and will send reminders for them
- [x] The activities that should be reminded are efficiently retrieved using a DB query
- [x] Multiple workers scaling possibility is taken into consideration

## Notes
A reminder is defined as:
- a Push Notification + a Journal Entry for the Elder user
- just a Journal Entry for the Caregiver user