### PR TITLE
App attempts to fetch Journal entries prior to successful login

### DIFF
--- a/application/src/modules/journal/JournalState.js
+++ b/application/src/modules/journal/JournalState.js
@@ -1,5 +1,6 @@
 // import Promise from 'bluebird';
 import {fromJS, Map} from 'immutable';
+import store from '../../redux/store';
 // import {loop, Effects} from 'redux-loop';
 
 import * as env from '../../../env';
@@ -26,7 +27,10 @@ export async function requestJournalData() {
   };
 }
 async function fetchPageData() {
-  var notificationsUrl = env.NOTIFICATIONS_REST_API + "?user=3";
+  // getting the user id from state after auth0 signin
+  var user_id = store.getState().get('auth').get('currentUser').get('userMetadata').get('user_id');
+  var notificationsUrl = env.NOTIFICATIONS_REST_API + "?user=" + user_id;
+  // override caching issues
   notificationsUrl += '&r=' + Math.floor(Math.random() * 10000);
 
   return fetch(notificationsUrl)

--- a/application/src/modules/journal/JournalView.js
+++ b/application/src/modules/journal/JournalView.js
@@ -28,9 +28,6 @@ const JournalView = React.createClass({
     refreshing: PropTypes.bool.isRequired,
     dispatch: PropTypes.func.isRequired
   },
-  // componentDidMount() {
-  //   this.onRefresh();
-  // },
   onRefresh() {
     this.props.dispatch(JournalStateActions.markStartRefreshing());
     this.props.dispatch(JournalStateActions.requestJournalData());

--- a/application/src/modules/journal/JournalView.js
+++ b/application/src/modules/journal/JournalView.js
@@ -28,10 +28,9 @@ const JournalView = React.createClass({
     refreshing: PropTypes.bool.isRequired,
     dispatch: PropTypes.func.isRequired
   },
-  componentDidMount() {
-    this.onRefresh();
-  },
-
+  // componentDidMount() {
+  //   this.onRefresh();
+  // },
   onRefresh() {
     this.props.dispatch(JournalStateActions.markStartRefreshing());
     this.props.dispatch(JournalStateActions.requestJournalData());

--- a/application/src/services/auth0.js
+++ b/application/src/services/auth0.js
@@ -4,8 +4,9 @@ import * as AuthStateActions from '../modules/auth/AuthState';
 import store from '../redux/store';
 const {Platform} = require('react-native');
 import Promise from 'bluebird';
-import * as HomepageStateActions from '../modules/homepage/HomepageState'
-import * as HomepageCaregiverStateActions from '../modules/homepage-caregiver/HomepageState'
+import * as HomepageStateActions from '../modules/homepage/HomepageState';
+import * as HomepageCaregiverStateActions from '../modules/homepage-caregiver/HomepageState';
+import * as JournalStateActions from '../modules/journal/JournalState';
 
 import Color from 'color';
 import variables from '../modules/variables/ElderGlobalVariables';
@@ -89,12 +90,20 @@ export function showLogin() {
             } else {
                 console.log('[auth] - user is [caregiver]. fetching data before redirecting...');
 
-                var promise_caregiver = new Promise((resolve, reject) => {
+                // caregiver general data fetch
+                var promise_caregiver_home = new Promise((resolve, reject) => {
                     store.dispatch(HomepageCaregiverStateActions.requestCaregiverData());
                     resolve("success");
                 });
 
-                promise_caregiver.then(() => {
+                // caregiver journal data fetch
+                // - separate fetch due to Pull to Refresh mechanics
+                var promise_caregiver_journal = new Promise((resolve, reject) => {
+                    store.dispatch(JournalStateActions.requestJournalData());
+                    resolve("success");
+                });
+
+                Promise.all(promise_caregiver_home, promise_caregiver_journal).then(() => {
                     console.log('[auth] - data has been fetched for [caregiver]. redirecting to homescreen...');
 
                     store.dispatch(redirectToOnboardingPage());


### PR DESCRIPTION
## Why
Following the progress made in #259 with adapting the app to use the new Journal entries API endpoint, we had to ensure a user's data is fetched only after he has logged in. This is now required as we need the user's id to be able to fetch the appropriate data from the API.

On the Caregiver's Journal screen however, we currently have implemented an independent system to fetch Journal entries for use with the Pull-To-Refresh feature. This system unfortunately attempts to fetch data before a user has a chance to authenticate, and not having access to his `user_id`, we were forced to [temporarily hard code it](https://github.com/cami-project/cami-project/commit/12f6fb7763e3cca835c2fddefbd59325ca6a8fb5).

## What
* [x] the Journal state logic is adapted, so that data fetches are only permitted once a user is logged in

## Notes
