### PR TITLE
Activity reminders for Caregiver & Elder get switched around

### DIFF
--- a/google_calendar/tasks.py
+++ b/google_calendar/tasks.py
@@ -35,7 +35,7 @@ def process_reminders():
     # Get current minute in UTC timestamp
     time_now = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M")
     time_now = time.mktime(time.strptime(time_now, "%a, %d %b %Y %H:%M"))
-    
+
     # Get all the activities that should be reminded in the current minute
     # and send reminders for each one of them
     activities = store_utils.activity_get(reminders__contains=int(time_now))
@@ -82,7 +82,7 @@ def send_reminder(activity, timestamp):
 
     # Caregiver Journal Entry
     store_utils.insert_journal_entry(
-        user="/api/v1/user/%d/" % 2,
+        user="/api/v1/user/%d/" % 3,
         type=journal_entry_type,
         severity='none',
         timestamp=timestamp,
@@ -92,7 +92,7 @@ def send_reminder(activity, timestamp):
 
     # Elder Journal Entry
     store_utils.insert_journal_entry(
-        user="/api/v1/user/%d/" % 3,
+        user="/api/v1/user/%d/" % 2,
         type=journal_entry_type,
         severity='none',
         timestamp=timestamp,
@@ -102,7 +102,7 @@ def send_reminder(activity, timestamp):
 
     # Elder Push Notification
     payload = {
-        "user_id": 3,
+        "user_id": 2,
         "message": elder_message
     }
 


### PR DESCRIPTION
## Why
Following the progress made in #275, we have successfully tested the sending and displaying of activity reminders inside the iOS app via the CAMI Cloud.

That being said, the only issue we've found with the reminders being sent is that the the Caregiver is receiving the Elder's message and vice-versa. 

## What
* [x] the logic for assembling the reminders to be sent to the Caregiver & Elder is fixed so that users receive the correct message according to their user id

## Notes
