### PR TITLE
Activity Journal entries are not displaying the correct severity colors

### DIFF
--- a/application/ios/Cami/Info.plist
+++ b/application/ios/Cami/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.5</string>
+	<string>1.2.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/application/src/icons-fa.json
+++ b/application/src/icons-fa.json
@@ -13,6 +13,7 @@
   "high": "exclamation",
   "low": "check",
   "ok": "check",
+  "info": "info",
   "wakeup": "check",
   "plus": "plus",
   "phone": "phone",

--- a/application/src/modules/homepage-caregiver/components/JournalEntry.js
+++ b/application/src/modules/homepage-caregiver/components/JournalEntry.js
@@ -21,7 +21,7 @@ const JournalEntry = React.createClass({
   matchStatus() {
     var status = this.props.status;
 
-    if (status) {
+    if (status !== 'none') {
       return status;
     } else {
       // this will be the case for activity-related entries

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -34,7 +34,7 @@ const HomepageView = React.createClass({
   matchSeverity() {
     severity = this.props.notification.get('severity');
 
-    if (severity) {
+    if (severity !== 'none') {
       return severity;
     } else {
       // this will be the case for activity-related entries

--- a/application/src/modules/journal/components/JournalEntry.js
+++ b/application/src/modules/journal/components/JournalEntry.js
@@ -113,7 +113,7 @@ const JournalEntry = React.createClass({
             <Text style={styles.time}>{time}</Text>
           </View>
           <View style={[styles.statusIcon, {backgroundColor: variables.colors.status[this.matchStatus()]}]}>
-            <Icon name={icons[this.props.status]} size={12} color={'white'}/>
+            <Icon name={icons[this.matchStatus()]} size={12} color={'white'}/>
           </View>
         </View>
         <View style={{flex: 7, borderLeftWidth: 2, borderColor: variables.colors.status[this.matchStatus()]}}>

--- a/application/src/modules/journal/components/JournalEntry.js
+++ b/application/src/modules/journal/components/JournalEntry.js
@@ -87,7 +87,7 @@ const JournalEntry = React.createClass({
   matchStatus() {
     var status = this.props.status;
 
-    if (status) {
+    if (status !== 'none') {
       return status;
     } else {
       // this will be the case for activity-related entries


### PR DESCRIPTION
## Why
Following the progress made in #275 with building the backend support for processing and sending activity reminders, we've discovered that the tweaks made in #276 & #277 inside the app to support the reminders, are not working as expected.

## What
* [x] the severity mapping for activity entries is investigated so that the app displays the colours associated with them

## Notes
