### PR TITLE
Insert event for reminder_sent into corresponding CAMI Cloud insertion queue

### DIFF
--- a/google_calendar/activities.py
+++ b/google_calendar/activities.py
@@ -84,8 +84,6 @@ def process_events(user, calendar, events, date_from, date_to):
 
     logger.debug("[google_calendar] Getting the activities from Store to compare them with the fetched events ...")
     db_events = store_utils.activity_get(
-        start__gte=int(time.mktime(date_from.timetuple())),
-        end__lte=int(time.mktime(date_to.timetuple())),
         user=user['id'],
         calendar_id=calendar['id']
     )

--- a/google_calendar/tasks.py
+++ b/google_calendar/tasks.py
@@ -139,6 +139,6 @@ def send_reminder(activity, timestamp):
         inserter.publish(json.dumps(payload))
 
     logger.debug(
-        "[google_calendar] Succesfully sent reminder for activity (%s).",
+        "[google_calendar] Successfully sent reminder for activity (%s).",
         str(activity)
     )

--- a/google_calendar/tasks.py
+++ b/google_calendar/tasks.py
@@ -51,7 +51,7 @@ def process_reminders():
 
 @app.task(name='google_calendar.send_reminder')
 def send_reminder(activity, timestamp):
-    activity_type = activity['activity_type'].decode('utf-8')
+    activity_type = activity['activity_type']
     caregiver_message_format = "Jim has %s at %s"
 
     if activity_type == 'personal':

--- a/google_calendar/tasks.py
+++ b/google_calendar/tasks.py
@@ -51,7 +51,7 @@ def process_reminders():
 
 @app.task(name='google_calendar.send_reminder')
 def send_reminder(activity, timestamp):
-    activity_type = activity['activity_type']
+    activity_type = activity['activity_type'].decode('utf-8')
     caregiver_message_format = "Jim has %s at %s"
 
     if activity_type == 'personal':
@@ -60,7 +60,7 @@ def send_reminder(activity, timestamp):
             "an appointment",
             "%s"
         )
-    elif activity_type == 'excercise':
+    elif activity_type == 'exercise':
         journal_entry_type = 'exercise'
         caregiver_message_format = caregiver_message_format % (
             "to exercise",
@@ -100,19 +100,41 @@ def send_reminder(activity, timestamp):
         description=activity['description']
     )
 
-    # Elder Push Notification
-    payload = {
-        "user_id": 2,
-        "message": elder_message
-    }
-
     with Connection(settings.BROKER_URL) as conn:
         channel = conn.channel()
 
+        # Elder Push Notification
+        payload = {
+            "user_id": 2,
+            "message": elder_message
+        }
         inserter = Producer(
             exchange=Exchange('push_notifications', type='topic'),
             channel=channel,
             routing_key="push_notification"
+        )
+        inserter.publish(json.dumps(payload))
+
+        # reminder_sent event
+        payload = {
+            "category": "user_notifications",
+            "content": {
+                "name": "reminder_send",
+                "value_type": "complex",
+                "value": {
+                    "user": { "id": 2 },
+                    "activity": activity
+                },
+                "annotations": {
+                    "timestamp": timestamp,
+                    "source": "google_calendar"
+                }
+            }
+        }
+        inserter = Producer(
+            exchange=Exchange('events', type='topic'),
+            channel=channel,
+            routing_key="event.user_notifications"
         )
         inserter.publish(json.dumps(payload))
 


### PR DESCRIPTION
## Why
Following the progress of #275, the CAMI system can now send reminders for activities, as they are scheduled in the Google Cloud backend.
In order to monitor the response of the user to these reminders, we need to insert the act of sending such a reminder as a **USER_NOTIFICATION** **event** in the CAMI Insertion endpoint.

## What
  - [x] the Google Calendar container is updated to also insert an event of type USER_NOTIFICATION upon issuing of a reminder
      - the event information must include information about the ID of the activity and the ID of the user referenced by the reminder

## Notes
