### PR TITLE
Implement Activity specific buttons in the Elder's app

### DIFF
--- a/application/api-examples/homepage/severity.medium.json
+++ b/application/api-examples/homepage/severity.medium.json
@@ -1,7 +1,13 @@
 {
   "notification": {
-    "type": "weight",
-    "severity": "medium",
-    "message": "Your weight loss plan is in danger"
+     "description":"Time for your medicine: Paracetamol\nRed box on the table.",
+     "id":87,
+     "message":"Jim has to take his medicine at 08:00",
+     "reference_id":null,
+     "resource_uri":"/api/v1/journal_entries/87/",
+     "severity":"none",
+     "timestamp":"1503732600",
+     "type":"medication",
+     "user":"/api/v1/user/3/"
   }
 }

--- a/application/src/modules/homepage/HomepageState.js
+++ b/application/src/modules/homepage/HomepageState.js
@@ -5,7 +5,7 @@ import store from '../../redux/store';
 import * as env from '../../../env';
 // import store from '../../redux/store';
 
-var json = require('../../../api-examples/homepage/severity.low.json');
+var json = require('../../../api-examples/homepage/severity.medium.json');
 
 // Initial state
 const initialState = fromJS(json);

--- a/application/src/modules/homepage/HomepageState.js
+++ b/application/src/modules/homepage/HomepageState.js
@@ -1,18 +1,23 @@
 import Promise from 'bluebird';
-import {fromJS} from 'immutable';
+import {fromJS, Map} from 'immutable';
 import {loop, Effects} from 'redux-loop';
 import store from '../../redux/store';
+import moment from 'moment';
 import * as env from '../../../env';
-// import store from '../../redux/store';
 
 var json = require('../../../api-examples/homepage/severity.medium.json');
 
 // Initial state
-const initialState = fromJS(json);
+const initialState = Map({
+  'notification': fromJS(json).get('notification'),
+  'acknowledged': false
+});
+
 
 // Actions
 const NOTIFICATION_RESPONSE = 'HomepageState/NOTIFICATION_RESPONSE';
 const TRIGGER_REQUEST = 'HomepageState/TRIGGER_REQUEST';
+const ACK_RESPONSE = 'HomepageState/ACK_RESPONSE';
 
 
 // Action creators
@@ -22,6 +27,13 @@ export async function requestNotification() {
     type: NOTIFICATION_RESPONSE,
     payload: await fetchNotification()
   };
+}
+
+export async function ackReminder(ack, reference_id) {
+  return {
+    type: ACK_RESPONSE,
+    payload: await postReminderAcknowledgement(ack, reference_id)
+  }
 }
 
 async function fetchNotification() {
@@ -52,8 +64,47 @@ async function fetchNotification() {
     });
 }
 
-// Simulates a periodic timer. This is for experimental purposes only, a proper timer should be used instead in
-// production.
+async function postReminderAcknowledgement(ack, reference_id) {
+  var user_id = store.getState().get('auth').get('currentUser').get('userMetadata').get('user_id');
+  var timestamp = moment().format('X');
+
+  return fetch(env.INSERTION_ENDPOINT + 'events/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        "category": "user_notifications",
+        "content": {
+          "name": "reminder_acknowledged",
+          "value_type": "complex",
+          "value": {
+            "ack": "ok",
+            "user": { "id": user_id },
+            "activity": { "id": reference_id }
+          },
+          "annotations": {
+            "timestamp": timestamp,
+            "source": "ios_app"
+          }
+        }
+      })
+    }).then((response) => {
+      if (response.status >= 200 && response.status < 300) {
+        console.log('[HomepageState] - Reminder acknowledged successfully: ' + JSON.stringify(response));
+        return response;
+      } else {
+        let error = new Error(response.statusText);
+        error.response = response;
+        throw error;
+      }
+    }).catch((error) => {
+      console.log('[HomepageState] - There was a problem with acknowledging reminder: ' + JSON.stringify(error));
+    });
+}
+
+// Simulates a periodic timer. This is for experimental purposes only, a proper
+// timer should be used instead in production.
 async function triggerFetchNotification() {
   return Promise.delay(env.POLL_INTERVAL_MILLIS).then(() => ({
     type: TRIGGER_REQUEST
@@ -69,15 +120,15 @@ export default function HomepageStateReducer(state = initialState, action = {}) 
         state,
         Effects.promise(requestNotification)
       );
-
     case NOTIFICATION_RESPONSE:
       // We got a notification update so let's update the state and then restart the timer.
       return loop(
         // TODO(@iprunache) stop triggering a render for every poll when the payload does not change; happens with immutable too.
-        state.set('notification', fromJS(action.payload)),
+        state.setIn(['notification'], fromJS(action.payload)),
         Effects.promise(triggerFetchNotification)
       );
-
+    case ACK_RESPONSE:
+      return state.setIn(['acknowledged'], true);
     default:
       return state;
   }

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -15,8 +15,10 @@ import icons from 'Cami/src/icons-fa';
 import variables from 'Cami/src/modules/variables/ElderGlobalVariables';
 import ElderButton from './components/ElderButton';
 
+import * as HomepageStateActions from './HomepageState';
 import {redirectToLoginPage} from '../navigation/NavigationState';
 import {logout} from '../auth/AuthState';
+
 const tapButtonSound = new Sound('sounds/knuckle.mp3', Sound.MAIN_BUNDLE, (error) => {
   if (error) {
     console.log('failed to load the sound', error);
@@ -63,8 +65,11 @@ const HomepageView = React.createClass({
     tapButtonSound.setVolume(1.0).play();
   },
 
-  acknowledgeEntry() {
+  acknowledgeReminder() {
     tapButtonSound.setVolume(1.0).play();
+
+    var reference_id = this.props.notification.get('reference_id');
+    this.props.dispatch(HomepageStateActions.ackReminder('ok', reference_id));
   },
 
   matchButtons(type) {

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -9,13 +9,13 @@ import {
 } from 'react-native';
 
 import Icon from 'react-native-vector-icons/FontAwesome';
+import Sound from 'react-native-sound';
+import Color from 'color';
 import icons from 'Cami/src/icons-fa';
 import variables from 'Cami/src/modules/variables/ElderGlobalVariables';
+import ElderButton from './components/ElderButton';
 
-var Color = require("color");
-
-var Sound = require('react-native-sound');
-var tapButtonSound = new Sound('sounds/knuckle.mp3', Sound.MAIN_BUNDLE, (error) => {
+const tapButtonSound = new Sound('sounds/knuckle.mp3', Sound.MAIN_BUNDLE, (error) => {
   if (error) {
     console.log('failed to load the sound', error);
   }

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -47,6 +47,64 @@ const HomepageView = React.createClass({
     }
   },
 
+  defaultAction() {
+    tapButtonSound.setVolume(1.0).play();
+  },
+
+  callCaregiver() {
+    tapButtonSound.setVolume(1.0).play();
+  },
+
+  acknowledgeEntry() {
+    tapButtonSound.setVolume(1.0).play();
+  },
+
+  matchButtons(type) {
+    console.log('[Homepage Elder] - Switching buttons according to ' + type + ' type');
+
+    switch (type) {
+      case 'exercise':
+      case 'medication':
+      case 'appointment':
+        return (
+          <View style={styles.buttonContainer}>
+            <ElderButton
+              type="default"
+              action={this.acknowledgeEntry}
+              severity={this.matchSeverity()}
+              text="OK"
+            />
+
+            <ElderButton
+              type="default"
+              action={this.defaultAction}
+              severity={this.matchSeverity()}
+              text="Cancel"
+            />
+          </View>
+        );
+      default:
+        return (
+          <View style={styles.buttonContainer}>
+            <ElderButton
+              type="panic"
+              action={this.callCaregiver}
+              severity={this.matchSeverity()}
+              text="Help"
+            />
+
+            <ElderButton
+              type="default"
+              action={this.defaultAction}
+              severity={this.matchSeverity()}
+              text="OK"
+            />
+          </View>
+        );
+    }
+
+  },
+
   render() {
     return (
       <View style={styles.container}>
@@ -104,41 +162,11 @@ const HomepageView = React.createClass({
               Hey Jim
             </Text>
             <Text style={[styles.text, {paddingTop: 20}]}>
-              {this.props.notification.get("message")}
+              {this.props.notification.get('message')}
             </Text>
           </View>
 
-          <View style={styles.buttonContainer}>
-            <TouchableOpacity
-              style={[
-                styles.button,
-                styles.buttonPanic,
-                {
-                  shadowColor: Color(variables.colors.status[this.matchSeverity()]).darken(.7).hexString()
-                }
-              ]}
-              onPress={() => tapButtonSound.setVolume(1.0).play()}
-            >
-              <Text style={[styles.buttonText, {color: 'white'}]}>
-                Help
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[
-                styles.button,
-                styles.buttonConfirm,
-                {
-                  shadowColor: Color(variables.colors.status[this.matchSeverity()]).darken(.7).hexString()
-                }
-              ]}
-              onPress={() => tapButtonSound.setVolume(1.0).play()}
-            >
-              <Text style={[styles.buttonText, {color: 'green'}]}>
-                OK
-              </Text>
-            </TouchableOpacity>
-          </View>
+          {this.matchButtons(this.props.notification.get('type'))}
         </View>
       </View>
     );
@@ -223,27 +251,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: variables.dimensions.width*.1,
     left: variables.dimensions.width*.1
-  },
-  button: {
-    ...buttonCircle,
-    alignSelf: 'center',
-    justifyContent: 'center',
-    shadowRadius: 40,
-    shadowOffset: {width: 0, height: 0},
-    shadowOpacity: 0.4,
-  },
-  buttonText: {
-    backgroundColor: 'transparent',
-    textAlign: 'center',
-    alignSelf: 'center',
-    fontSize: 22,
-    fontWeight: 'bold'
-  },
-  buttonConfirm: {
-    backgroundColor: 'white',
-  },
-  buttonPanic: {
-    backgroundColor: variables.colors.panic
   }
 });
 

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -73,30 +73,47 @@ const HomepageView = React.createClass({
   },
 
   matchButtons(type) {
-    console.log('[Homepage Elder] - Switching buttons according to ' + type + ' type');
-
     switch (type) {
       case 'exercise':
       case 'medication':
       case 'appointment':
-        return (
-          <View style={styles.buttonContainer}>
-            <ElderButton
-              type="default"
-              action={this.acknowledgeEntry}
-              severity={this.matchSeverity()}
-              text="OK"
-            />
+        if (!this.props.acknowledged) {
+          console.log('[HomepageView] - Using button layout for ' + type + ' type Journal Entry, that hasn\'t been acknowledged.');
 
-            <ElderButton
-              type="default"
-              action={this.defaultAction}
-              severity={this.matchSeverity()}
-              text="Cancel"
-            />
-          </View>
-        );
+          return (
+            <View style={styles.buttonContainer}>
+              <ElderButton
+                type="default"
+                action={this.acknowledgeReminder}
+                severity={this.matchSeverity()}
+                text="OK"
+              />
+
+              <ElderButton
+                type="default"
+                action={this.defaultAction}
+                severity={this.matchSeverity()}
+                text="Cancel"
+              />
+            </View>
+          );
+        } else {
+            console.log('[HomepageView] - Using button layout for ' + type + ' type Journal Entry, that has been acknowledged.');
+
+            return (
+            <View style={styles.buttonContainer}>
+              <ElderButton
+                type="panic"
+                action={this.callCaregiver}
+                severity={this.matchSeverity()}
+                text="Help"
+              />
+            </View>
+          );
+        }
       default:
+        console.log('[HomepageView] - Using default button layout for ' + type + ' type Journal Entry.');
+
         return (
           <View style={styles.buttonContainer}>
             <ElderButton

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -27,6 +27,7 @@ const HomepageView = React.createClass({
   propTypes: {
     notification: PropTypes.instanceOf(Map).isRequired,
     username: PropTypes.string.isRequired,
+    acknowledged: PropTypes.bool.isRequired,
     dispatch: PropTypes.func.isRequired
   },
 

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -15,6 +15,8 @@ import icons from 'Cami/src/icons-fa';
 import variables from 'Cami/src/modules/variables/ElderGlobalVariables';
 import ElderButton from './components/ElderButton';
 
+import {redirectToLoginPage} from '../navigation/NavigationState';
+import {logout} from '../auth/AuthState';
 const tapButtonSound = new Sound('sounds/knuckle.mp3', Sound.MAIN_BUNDLE, (error) => {
   if (error) {
     console.log('failed to load the sound', error);
@@ -25,7 +27,12 @@ const HomepageView = React.createClass({
   propTypes: {
     notification: PropTypes.instanceOf(Map).isRequired,
     username: PropTypes.string.isRequired,
-    logout: PropTypes.func.isRequired
+    dispatch: PropTypes.func.isRequired
+  },
+
+  logoutElder() {
+    this.props.dispatch(logout());
+    this.props.dispatch(redirectToLoginPage());
   },
 
   // some Journal entries don't come w/ severity information
@@ -129,7 +136,7 @@ const HomepageView = React.createClass({
           <View style={styles.logoutButtonContainer}>
             <TouchableOpacity
               style={styles.logoutButton}
-              onPress={() => tapButtonSound.setVolume(1.0).play() && this.props.logout()}
+              onPress={() => tapButtonSound.setVolume(1.0).play() && this.logoutElder()}
             >
               <Icon
                 name={icons.logout}

--- a/application/src/modules/homepage/HomepageViewContainer.js
+++ b/application/src/modules/homepage/HomepageViewContainer.js
@@ -5,6 +5,7 @@ import HomepageView from './HomepageView';
 export default connect(
   state => ({
     notification: state.getIn(['homepage', 'notification']),
-    username: state.getIn(['auth', 'currentUser', 'name'])
+    username: state.getIn(['auth', 'currentUser', 'name']),
+    acknowledged: state.getIn(['homepage', 'acknowledged'])
   })
 )(HomepageView);

--- a/application/src/modules/homepage/HomepageViewContainer.js
+++ b/application/src/modules/homepage/HomepageViewContainer.js
@@ -1,18 +1,10 @@
 import {connect} from 'react-redux';
 
 import HomepageView from './HomepageView';
-import {redirectToLoginPage} from '../navigation/NavigationState';
-import {logout} from '../auth/AuthState';
 
 export default connect(
   state => ({
     notification: state.getIn(['homepage', 'notification']),
     username: state.getIn(['auth', 'currentUser', 'name'])
-  }),
-  dispatch => ({
-    logout() {
-      dispatch(logout());
-      dispatch(redirectToLoginPage());
-    }
   })
 )(HomepageView);

--- a/application/src/modules/homepage/components/ElderButton.js
+++ b/application/src/modules/homepage/components/ElderButton.js
@@ -1,0 +1,67 @@
+import React, {PropTypes} from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity
+} from 'react-native';
+import Color from 'color';
+import variables from '../../variables/ElderGlobalVariables';
+
+import * as HomepageState from '../HomepageState';
+
+const ElderButton = React.createClass({
+  propTypes: {
+    type: PropTypes.string.isRequired,
+    action: PropTypes.func.isRequired,
+    severity: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired
+  },
+
+  render() {
+    return(
+      <TouchableOpacity
+        style={[
+          styles.button,
+          {
+            shadowColor: Color(variables.colors.status[this.props.severity]).darken(.7).hexString(),
+            backgroundColor: this.props.type === 'panic' ? variables.colors.panic : 'white'
+          }
+        ]}
+        onPress={this.props.action}
+      >
+        <Text style={[
+          styles.buttonText,
+          {color: this.props.type === 'panic' ? 'white' : 'green'}
+        ]}>{this.props.text}</Text>
+      </TouchableOpacity>
+    );
+  }
+});
+
+const buttonCircle = {
+  borderWidth: 0,
+  borderRadius: 45,
+  width: 90,
+  height: 90
+};
+
+const styles = StyleSheet.create({
+  button: {
+    ...buttonCircle,
+    alignSelf: 'center',
+    justifyContent: 'center',
+    shadowRadius: 40,
+    shadowOffset: {width: 0, height: 0},
+    shadowOpacity: 0.4,
+  },
+  buttonText: {
+    backgroundColor: 'transparent',
+    textAlign: 'center',
+    alignSelf: 'center',
+    fontSize: 22,
+    fontWeight: 'bold'
+  },
+});
+
+export default ElderButton;


### PR DESCRIPTION
## Why
In #277 we've added support for Activity journal entries on the Elder's side of the app.

As a first step towards having interactive scenarios centred around an Activity, we want to be able to know if the Elder is aware of the Activity reminder that he's been sent.

## What
* [ ] the Elder's home screen displays **Ok** and **Cancel** buttons if currently showing an Activity type journal entry
* [ ] the buttons are adapted to post simple message back to the CAMI system at the `insertion` endpoint from #254
   * _the content of the simple messages will be decided after further progress will be made with creating support for reminders inside the CAMI Cloud_
 
## Notes
/cc @cretualexandru 