### PR TITLE
Mark reminder-related JournalEntries as acknowledged when the user takes an action upon the reminder

### DIFF
--- a/application/ios/Cami/Info.plist
+++ b/application/ios/Cami/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/application/src/modules/homepage/HomepageState.js
+++ b/application/src/modules/homepage/HomepageState.js
@@ -9,8 +9,7 @@ var json = require('../../../api-examples/homepage/severity.medium.json');
 
 // Initial state
 const initialState = Map({
-  'notification': fromJS(json).get('notification'),
-  'acknowledged': false
+  'notification': fromJS(json).get('notification')
 });
 
 
@@ -128,7 +127,7 @@ export default function HomepageStateReducer(state = initialState, action = {}) 
         Effects.promise(triggerFetchNotification)
       );
     case ACK_RESPONSE:
-      return state.setIn(['acknowledged'], true);
+      return state.setIn(['notification', 'acknowledged'], true);
     default:
       return state;
   }

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -29,7 +29,6 @@ const HomepageView = React.createClass({
   propTypes: {
     notification: PropTypes.instanceOf(Map).isRequired,
     username: PropTypes.string.isRequired,
-    acknowledged: PropTypes.bool.isRequired,
     dispatch: PropTypes.func.isRequired
   },
 
@@ -68,8 +67,9 @@ const HomepageView = React.createClass({
   acknowledgeReminder() {
     tapButtonSound.setVolume(1.0).play();
 
-    var reference_id = this.props.notification.get('reference_id');
-    this.props.dispatch(HomepageStateActions.ackReminder('ok', reference_id));
+    var reference_id = this.props.notification.get('reference_id'),
+        entry_id = this.props.notification.get('id');
+    this.props.dispatch(HomepageStateActions.ackReminder('ok', reference_id, entry_id));
   },
 
   matchButtons(type) {
@@ -77,7 +77,7 @@ const HomepageView = React.createClass({
       case 'exercise':
       case 'medication':
       case 'appointment':
-        if (!this.props.acknowledged) {
+        if (!this.props.notification.get('acknowledged')) {
           console.log('[HomepageView] - Using button layout for ' + type + ' type Journal Entry, that hasn\'t been acknowledged.');
 
           return (


### PR DESCRIPTION
## Why
In order to implement the reminders with as little effort as possible, we decided to re-use the journal entries implementation, but we need to adapt it to fully integrate with the reminders.

The new `acknowledged` field would be used to mark a reminder-related journal entry when the user take an action upon the reminder, so the reminder is not brought out to the user again.

## What
- [x] Send a `PATCH` request to the `store` to set the `acknowledge` field of `JournalEntry` to `true` when the user take an action upon the reminder in the iOS application

## Notes
Part of #278.