### PR TITLE
Update iOS app to fetch measurements from new endpoints

### DIFF
--- a/application/src/modules/homepage-caregiver/HomepageState.js
+++ b/application/src/modules/homepage-caregiver/HomepageState.js
@@ -128,7 +128,7 @@ async function fetchPageData() {
 
       var weightApiUrl = env.WEIGHT_MEASUREMENTS_LAST_VALUES;
       var heartRateApiUrl = env.HEARTRATE_MEASUREMENTS_LAST_VALUES;
-      var stepsCountApiUrl = env.STEPS_MEASUREMENTS_LAST_VALUES;
+      var stepsCountApiUrl = env.STEPS_MEASUREMENTS_LAST_VALUES + '?units=7&resolution=days';
       var activitiesApiUrl = env.ACTIVITIES_LAST_EVENTS;
 
       return fetch(activitiesApiUrl).then((response) => response.json())


### PR DESCRIPTION
## Why
Following the recent refactoring effort on the backend side, we need to update the endpoints used to fetch measurements to include data received from other devices.

## What
* [ ] the iOS app is adapted to make use of the new Store API measurement endpoints

## Notes
@asorici's debugging conclusions:
```
I think I've found the error for missing updates when not performed using the withings scale or the LG watch

- if the current iOS application version is using this env.js config
https://github.com/cami-project/cami-project/blob/master/application/env.example.js
notice that the WEIGHT_MEASUREMENTS_LAST_VALUES is still set to retrieve data from the `medical_compliance` endpoint instead of directly from the CAMI Store
- instead of http://cami.vitaminsoftware.com:8000/api/v1/weight-measurements/last_values/
we should have something like: http://cami.vitaminsoftware.com:8008/api/v1/measurement/?measurement_type=weight&order_by=-timestamp&limit=10
```