### PR TITLE
Adapt iOS app to make use of GMT time instead of local time

### DIFF
--- a/application/src/modules/activities/ActivitiesView.js
+++ b/application/src/modules/activities/ActivitiesView.js
@@ -28,7 +28,7 @@ const ActivitiesView = React.createClass({
     if(this.props.events.size > 0) {
       const _scrollView = this.scrollView;
       // we need the nextEventId to calculate scrolling distance
-      const nextEventId = this.findNextEventId(this.props.events, moment());
+      const nextEventId = this.findNextEventId(this.props.events, moment().utc());
       // scroll offset to get last event in view
       // - used when there aren't enough future events to justify nextEvent hidden under header
       const scrollToEndOffset = ((this.props.events.size * 127) - (variables.dimensions.height - 140 - 49 - 20));
@@ -80,7 +80,7 @@ const ActivitiesView = React.createClass({
   },
 
   render() {
-    const today = moment();
+    const today = moment().utc();
     // placeholder for the events to be itterated upon
     const events = [];
     // id of next event from the list of events received form the API
@@ -90,13 +90,13 @@ const ActivitiesView = React.createClass({
       : null;
 
     // moment of next event, used for header dates formatting
-    const nextEventDate = nextEventId ? moment.unix(this.props.events.get(nextEventId).get('start')) : null;
+    const nextEventDate = nextEventId ? moment.unix(this.props.events.get(nextEventId).get('start')).utc() : null;
     // month name of 1st event that will be used to selectively display month separators
-    let monthKey = moment.unix(this.props.events.get(0).get('start')).format('MMMM');
+    let monthKey = moment.unix(this.props.events.get(0).get('start')).utc().format('MMMM');
 
     this.props.events.forEach((event, index) => {
       // every time a month changes we show a visual separator inside the timeline
-      const month = moment.unix(event.get('start')).format('MMMM');
+      const month = moment.unix(event.get('start')).utc().format('MMMM');
       if (month !== monthKey) {
         monthKey = month;
         events.push(

--- a/application/src/modules/activities/components/ActivityEntry.js
+++ b/application/src/modules/activities/components/ActivityEntry.js
@@ -23,7 +23,7 @@ const ActivityEntry = React.createClass({
   },
 
   render() {
-    const eventTime = moment.unix(this.props.timestamp);
+    const eventTime = moment.unix(this.props.timestamp).utc();
 
     return (
       <View style={[

--- a/application/src/modules/homepage-caregiver/components/JournalEntry.js
+++ b/application/src/modules/homepage-caregiver/components/JournalEntry.js
@@ -35,7 +35,7 @@ const JournalEntry = React.createClass({
   },
 
   render() {
-    const time = moment(new Date(this.props.timestamp * 1000)).format('HH:mm');
+    const time = moment(new Date(this.props.timestamp * 1000)).utc().format('HH:mm');
 
     return (
       <View style={styles.journalEntry}>

--- a/application/src/modules/journal/JournalView.js
+++ b/application/src/modules/journal/JournalView.js
@@ -34,17 +34,17 @@ const JournalView = React.createClass({
   },
 
   render() {
-    const todayDateText = (this.props.events.length > 0) ? moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).format(DATE_FORMAT) : '';
-    const firstEventDateText = (this.props.events.length > 0) ? moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).format(DATE_FORMAT) : '';
+    const todayDateText = (this.props.events.length > 0) ? moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).utc().format(DATE_FORMAT) : '';
+    const firstEventDateText = (this.props.events.length > 0) ? moment(new Date(this.props.events.get(0).get('timestamp') * 1000)).utc().format(DATE_FORMAT) : '';
     const headerDateText = (this.props.events.length > 0) ? (todayDateText == firstEventDateText ? 'Today ' + todayDateText : firstEventDateText) : '';
 
     const events = [];
     let dayKey = firstEventDateText;
     this.props.events.forEach((event, index) => {
-      const day = moment(new Date(event.get('timestamp') * 1000)).format(DATE_FORMAT);
+      const day = moment(new Date(event.get('timestamp') * 1000)).utc().format(DATE_FORMAT);
       if (day != dayKey) {
         dayKey = day;
-        const weekDayText = moment(new Date(event.get('timestamp') * 1000)).format(WEEK_DATE_FORMAT);
+        const weekDayText = moment(new Date(event.get('timestamp') * 1000)).utc().format(WEEK_DATE_FORMAT);
         events.push(
           <View key={'text' + index} style={[styles.dateContainer, {flex: 1}]}>
             <View style={styles.dateRuler}><View style={styles.dateBullet}/></View>

--- a/application/src/modules/journal/components/JournalEntry.js
+++ b/application/src/modules/journal/components/JournalEntry.js
@@ -101,7 +101,7 @@ const JournalEntry = React.createClass({
   },
 
   render() {
-    const time = moment(new Date(this.props.timestamp * 1000)).format('HH:mm');
+    const time = moment(new Date(this.props.timestamp * 1000)).utc().format('HH:mm');
 
     return (
       <View style={styles.journalEntry}>


### PR DESCRIPTION
## Why
We need to have consistent time references within the app.

Right now messages containing time references that get assembled server-side and displayed in the app, differ from the time displayed alongside them.

Example for reminder that references an event that happens at 11:00.
```
10:30: Jim has to take his medicine at 8:00 AM.
```

## What
* [ ] a list of places inside the app where the time references need to be changed to GMT time is assembled inside a comment to this issue
* [x] each time reference inside the app's logic is corrected so that we have a consistent display of time throughout

## Notes
