### PR TITLE
Add UDID of new iPhone for AAL Forum Demo to accepted list 

### DIFF
--- a/application/ios/Cami/Info.plist
+++ b/application/ios/Cami/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.7</string>
+	<string>1.2.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## Why
For the upcoming AAL Forum we need the means to showcase both the CAMI caregiver and the end-user iOS applications at the same time. An additional iPhone device has been acquired which needs to be whitelisted.

## What
  - add the following UDID, for an iPhone 5S, to the list of white listed ones: `5e1724421fae656a16e2bb2ed62a248afa29b6a1`

## Notes
