### PR TITLE
Add support for elder reminder postpone action in iOS app

### DIFF
--- a/application/src/modules/homepage/HomepageState.js
+++ b/application/src/modules/homepage/HomepageState.js
@@ -81,7 +81,7 @@ async function postReminderAcknowledgement(ack, reference_id, entry_id) {
           "name": "reminder_acknowledged",
           "value_type": "complex",
           "value": {
-            "ack": "ok",
+            "ack": ack,
             "user": { "id": user_id },
             "activity": { "id": reference_id }
           },

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -72,12 +72,20 @@ const HomepageView = React.createClass({
     this.props.dispatch(HomepageStateActions.ackReminder('ok', reference_id, entry_id));
   },
 
+  snoozeReminder() {
+    tapButtonSound.setVolume(1.0).play();
+
+    var reference_id = this.props.notification.get('reference_id'),
+        entry_id = this.props.notification.get('id');
+    this.props.dispatch(HomepageStateActions.ackReminder('snooze', reference_id, entry_id));
+  },
+
   matchButtons(type) {
     switch (type) {
       case 'exercise':
       case 'medication':
       case 'appointment':
-        if (!this.props.notification.get('acknowledged')) {
+        if (this.props.notification.get('acknowledged') == null) {
           console.log('[HomepageView] - Using button layout for ' + type + ' type Journal Entry, that hasn\'t been acknowledged.');
 
           return (
@@ -91,9 +99,9 @@ const HomepageView = React.createClass({
 
               <ElderButton
                 type="default"
-                action={this.defaultAction}
+                action={this.snoozeReminder}
                 severity={this.matchSeverity()}
-                text="Cancel"
+                text="Snooze"
               />
             </View>
           );

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -5,7 +5,8 @@ import {
   Text,
   View,
   Image,
-  TouchableOpacity
+  TouchableOpacity,
+  Alert
 } from 'react-native';
 
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -58,10 +59,26 @@ const HomepageView = React.createClass({
 
   defaultAction() {
     tapButtonSound.setVolume(1.0).play();
+
+    Alert.alert(
+      'Default Action',
+      'This action hasn\'t been implemented yet.',
+      [
+        {text: 'OK', onPress: () => console.log('[HomepageView] - Elder triggered the default button action.')}
+      ]
+    );
   },
 
   callCaregiver() {
     tapButtonSound.setVolume(1.0).play();
+
+    Alert.alert(
+      'Help is on the way!',
+      'The Caregiver has been informed of your emergency.',
+      [
+        {text: 'OK', onPress: () => console.log('[HomepageView] - Elder pressed the HELP button.')}
+      ]
+    );
   },
 
   acknowledgeReminder() {
@@ -70,6 +87,14 @@ const HomepageView = React.createClass({
     var reference_id = this.props.notification.get('reference_id'),
         entry_id = this.props.notification.get('id');
     this.props.dispatch(HomepageStateActions.ackReminder('ok', reference_id, entry_id));
+
+    Alert.alert(
+      'Reminder was acknowledged',
+      'Thank you for your input!',
+      [
+        {text: 'OK', onPress: () => console.log('[HomepageView] - Elder acknowledged the event.')}
+      ]
+    );
   },
 
   snoozeReminder() {
@@ -78,6 +103,14 @@ const HomepageView = React.createClass({
     var reference_id = this.props.notification.get('reference_id'),
         entry_id = this.props.notification.get('id');
     this.props.dispatch(HomepageStateActions.ackReminder('snooze', reference_id, entry_id));
+
+    Alert.alert(
+      'Reminder was snoozed',
+      'Thank you for your input!',
+      [
+        {text: 'Ok', onPress: () => console.log('[HomepageView] - Elder snoozed the event.')}
+      ]
+    );
   },
 
   matchButtons(type) {


### PR DESCRIPTION
## Why
Following the progress made in #278 & #313, the Elder user now has the ability to OK a reminder that's been sent to him so that the CAMI system will later on be able to factor it into the decisions that need to be taken.

An Elder should also have the option to Postpone a reminder and have the system take his decision into account.

## What
* [x] the iOS app is adapted to include a Postpone button for Reminder-related Journal entries
* [x] pressing the Postpone button, saves the acknowledged state of the Journal entry server-side
* [x] pressing the Postpone button, sends a respective acknowledge event to the CAMI Cloud Insertion queue

## Notes
