### PR TITLE
Elder's iOS app isn't updating automatically to latest notification

### DIFF
--- a/application/src/modules/homepage/HomepageState.js
+++ b/application/src/modules/homepage/HomepageState.js
@@ -21,6 +21,7 @@ const ACK_RESPONSE = 'HomepageState/ACK_RESPONSE';
 
 // Action creators
 export async function requestNotification() {
+  console.log('[HomepageState] - Requesting [elder] data fetch.');
   // Do an async fetch fot the latest notification.
   return {
     type: NOTIFICATION_RESPONSE,
@@ -53,7 +54,7 @@ async function fetchNotification() {
           return initialState.getIn(['notification']);
         }
 
-        console.log('[HomepageState] - sucessfully fetched [elder] data');
+        console.log('[HomepageState] - sucessfully fetched [elder] data: ' + JSON.stringify(json.objects[0]));
         return json.objects[0];
       });
     })
@@ -120,7 +121,7 @@ async function postReminderAcknowledgement(ack, reference_id, journal_entry_id) 
           }
 
         }).catch((error) => {
-          console.log('[HomepageState] - There was a problem patching the Joournal Entry acknowledged field: ' + JSON.stringify(error));
+          console.log('[HomepageState] - There was a problem patching the Journal Entry acknowledged field: ' + JSON.stringify(error));
         });
 
       } else {
@@ -129,13 +130,15 @@ async function postReminderAcknowledgement(ack, reference_id, journal_entry_id) 
         throw error;
       }
     }).catch((error) => {
-      console.log('[HomepageState] - There was a problem with acknowledging reminder: ' + JSON.stringify(error));
+      console.log('[HomepageState] - There was a problem posting a [' + ack + '] ack on the insertion queue: ' + JSON.stringify(error));
     });
 }
 
 // Simulates a periodic timer. This is for experimental purposes only, a proper
 // timer should be used instead in production.
 async function triggerFetchNotification() {
+  console.log('[HomepageState] - Triggered data fetch for [elder] in ' + (env.POLL_INTERVAL_MILLIS / 1000) + ' seconds.');
+
   return Promise.delay(env.POLL_INTERVAL_MILLIS).then(() => ({
     type: TRIGGER_REQUEST
   }))

--- a/application/src/modules/homepage/HomepageState.js
+++ b/application/src/modules/homepage/HomepageState.js
@@ -28,10 +28,10 @@ export async function requestNotification() {
   };
 }
 
-export async function ackReminder(ack, reference_id, entry_id) {
+export async function ackReminder(ack, reference_id, journal_entry_id) {
   return {
     type: ACK_RESPONSE,
-    payload: await postReminderAcknowledgement(ack, reference_id, entry_id)
+    payload: await postReminderAcknowledgement(ack, reference_id, journal_entry_id)
   }
 }
 
@@ -63,7 +63,7 @@ async function fetchNotification() {
     });
 }
 
-async function postReminderAcknowledgement(ack, reference_id, entry_id) {
+async function postReminderAcknowledgement(ack, reference_id, journal_entry_id) {
   var user_id = store.getState().get('auth').get('currentUser').get('userMetadata').get('user_id');
   var timestamp = moment().format('X');
 
@@ -83,6 +83,7 @@ async function postReminderAcknowledgement(ack, reference_id, entry_id) {
           "value": {
             "ack": ack,
             "user": { "id": user_id },
+            "journal": { "id": journal_entry_id },
             "activity": { "id": reference_id }
           },
           "annotations": {
@@ -98,7 +99,7 @@ async function postReminderAcknowledgement(ack, reference_id, entry_id) {
         // Changing status of acknowledged field of the Journal Entry
         // - We need to remember the acknowledged state of a reminder so that we
         // no longer allow users to re-ack it
-        return fetch(env.NOTIFICATIONS_REST_API + entry_id + '/', {
+        return fetch(env.NOTIFICATIONS_REST_API + journal_entry_id + '/', {
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json'

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -85,8 +85,8 @@ const HomepageView = React.createClass({
     tapButtonSound.setVolume(1.0).play();
 
     var reference_id = this.props.notification.get('reference_id'),
-        entry_id = this.props.notification.get('id');
-    this.props.dispatch(HomepageStateActions.ackReminder('ok', reference_id, entry_id));
+        journal_entry_id = this.props.notification.get('id');
+    this.props.dispatch(HomepageStateActions.ackReminder('ok', reference_id, journal_entry_id));
 
     Alert.alert(
       'Reminder was acknowledged',
@@ -101,8 +101,8 @@ const HomepageView = React.createClass({
     tapButtonSound.setVolume(1.0).play();
 
     var reference_id = this.props.notification.get('reference_id'),
-        entry_id = this.props.notification.get('id');
-    this.props.dispatch(HomepageStateActions.ackReminder('snooze', reference_id, entry_id));
+        journal_entry_id = this.props.notification.get('id');
+    this.props.dispatch(HomepageStateActions.ackReminder('snooze', reference_id, journal_entry_id));
 
     Alert.alert(
       'Reminder was snoozed',

--- a/application/src/modules/homepage/HomepageView.js
+++ b/application/src/modules/homepage/HomepageView.js
@@ -22,7 +22,7 @@ import {logout} from '../auth/AuthState';
 
 const tapButtonSound = new Sound('sounds/knuckle.mp3', Sound.MAIN_BUNDLE, (error) => {
   if (error) {
-    console.log('failed to load the sound', error);
+    console.log('[HomepageState] - Failed to load the button tap sound', error);
   }
 });
 


### PR DESCRIPTION
## Why
Every time the Elder opens the iOS app, he needs to be informed of the latest activity or notification that has been issued. 

## What
* [ ] the automatic fetch for notifications is fixed so the app updates to reflect the latest notification available

## Notes
Currently, the app only appears to fetch notifications after a successful login, but remains stale afterwards.