### PR TITLE
iOS app crashing when no weight data is available

### DIFF
--- a/application/src/modules/homepage-caregiver/components/StatusChart.js
+++ b/application/src/modules/homepage-caregiver/components/StatusChart.js
@@ -75,26 +75,37 @@ const StatusChart = React.createClass({
             <Icon name={this.props.icon} size={34} color={variables.colors.status[this.props.status]}/>
           </View>
           <View style={chartStyles.infoContainer}>
-            <Text style={chartStyles.value}>
-              {
-                this.props.decimals > 0
-                  ? currentValue.toFixed(this.props.decimals)
-                  : currentValue
-              } <Text style={chartStyles.unit}>{this.props.unit}</Text>
-            </Text>
+            {
+              this.props.data.size > 0 ?
+                <Text style={chartStyles.value}>
+                  {
+                    this.props.decimals > 0
+                      ? currentValue.toFixed(this.props.decimals)
+                      : currentValue
+                  } <Text style={chartStyles.unit}>{this.props.unit}</Text>
+                </Text>
+                :
+                <Text style={chartStyles.value}>
+                  <Text>N/A</Text> <Text style={chartStyles.unit}>{this.props.unit}</Text>
+                </Text>
+            }
             <Text style={chartStyles.description}>{this.props.text}</Text>
           </View>
         </View>
         <View style={chartStyles.chartContainer}>
-          <Chart
-            style={chartStyles.chart}
-            data={arrayData}
-            type="line"
-            showGrid={false}
-            showAxis={false}
-            color="#999999"
-            lineWidth={2}
-          />
+          {
+            this.props.data.size > 0 ?
+              <Chart
+                style={chartStyles.chart}
+                data={arrayData}
+                type="line"
+                showGrid={false}
+                showAxis={false}
+                color="#999999"
+                lineWidth={2}
+              />
+              : <Text style={chartStyles.description}>No weight information</Text>
+          }
         </View>
       </View>
     );


### PR DESCRIPTION
## Why
For the upcoming CAMI Field Trials, we need to adapt the iOS app and system to work for multiple users that may not record all the supported measurements information.

## What
* [x] the iOS app falls back gracefully when no weight information is available for the respective user

## Notes
Initial debugging reveals that the Caregiver's home screen weight chart crashes the app if no data is available.