### PR TITLE
Logging out of the iOS app doesn't stop data fetch

### DIFF
--- a/application/src/modules/homepage/HomepageState.js
+++ b/application/src/modules/homepage/HomepageState.js
@@ -149,17 +149,27 @@ export default function HomepageStateReducer(state = initialState, action = {}) 
   switch (action.type) {
     case TRIGGER_REQUEST:
       // State doesn't change, we just want to trigger a notification fetch.
-      return loop(
-        state,
-        Effects.promise(requestNotification)
-      );
+      // - checking if a user is still logged to see if a new fetch should be triggered
+      if (store.getState().get('auth').get('isLoggedIn')) {
+        return loop(
+          state,
+          Effects.promise(requestNotification)
+        );
+      } else {
+        return state;
+      }
     case NOTIFICATION_RESPONSE:
       // We got a notification update so let's update the state and then restart the timer.
-      return loop(
-        // TODO(@iprunache) stop triggering a render for every poll when the payload does not change; happens with immutable too.
-        state.setIn(['notification'], fromJS(action.payload)),
-        Effects.promise(triggerFetchNotification)
-      );
+      // - checking if a user is still logged to see if a new fetch should be triggered
+      if (store.getState().get('auth').get('isLoggedIn')) {
+        return loop(
+          // TODO(@iprunache) stop triggering a render for every poll when the payload does not change; happens with immutable too.
+          state.setIn(['notification'], fromJS(action.payload)),
+          Effects.promise(triggerFetchNotification)
+        );
+      } else {
+        return state;
+      }
     case ACK_RESPONSE:
       return state.setIn(['notification', 'acknowledged'], true);
     default:


### PR DESCRIPTION
## Why
For the upcoming CAMI field trials, we need to provide the partners with the ability to quickly switch between elder/caregiver users, so they can ensure that the system is working accordingly.

## What
* [x] logging out of the iOS app stops fetching data for the previously signed in user

## Notes
In #417 we've added support for fetching caregiver data based on the current logged in user. Due to the fact the the app still fetches data using the user_id/elder_id established during the previous session, when the app is switched to a different user type (caregiver -> elder_id), the app crashes.